### PR TITLE
Add start timestamp

### DIFF
--- a/config.go
+++ b/config.go
@@ -24,6 +24,9 @@ type Config struct {
 
 	// Delay between tests for the client or shard numbers changing
 	shardCheckFrequency time.Duration
+
+	// Starting timestamp of the shard iterator, if "AT_TIMESTAMP" is the desired iterator type
+	iteratorStartTimestamp *time.Time
 	// ---------- [ For the leader (first client alphabetically) ] ----------
 	// Time between leader actions
 	leaderActionFrequency time.Duration
@@ -102,6 +105,12 @@ func (c Config) WithBufferSize(bufferSize int) Config {
 // WithStats returns a Config with a modified stats
 func (c Config) WithStats(stats StatReceiver) Config {
 	c.stats = stats
+	return c
+}
+
+// WithIteratorStartTimestamp returns a Config with a modified iteratorStartTimestamp
+func (c Config) WithIteratorStartTimestamp(timestamp *time.Time) Config {
+	c.iteratorStartTimestamp = timestamp
 	return c
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -13,6 +13,7 @@ func TestConfigDefault(t *testing.T) {
 	config := NewConfig()
 	err := validateConfig(&config)
 	require.NoError(t, err)
+	require.Nil(t, config.iteratorStartTimestamp)
 }
 
 func TestConfigErrors(t *testing.T) {
@@ -55,13 +56,15 @@ func TestConfigErrors(t *testing.T) {
 
 func TestConfigWithMethods(t *testing.T) {
 	stats := &NoopStatReceiver{}
+	tstamp := time.Now()
 	config := NewConfig().
 		WithBufferSize(1).
 		WithCommitFrequency(1 * time.Second).
 		WithShardCheckFrequency(1 * time.Second).
 		WithLeaderActionFrequency(1 * time.Second).
 		WithThrottleDelay(1 * time.Second).
-		WithStats(stats)
+		WithStats(stats).
+		WithIteratorStartTimestamp(&tstamp)
 
 	err := validateConfig(&config)
 	require.NoError(t, err)
@@ -72,4 +75,5 @@ func TestConfigWithMethods(t *testing.T) {
 	require.Equal(t, 1*time.Second, config.shardCheckFrequency)
 	require.Equal(t, 1*time.Second, config.leaderActionFrequency)
 	require.Equal(t, stats, config.stats)
+	require.Equal(t, &tstamp, config.iteratorStartTimestamp)
 }


### PR DESCRIPTION
- Pulls in the most recent commit from upstream (which improves error handling)
- Adds a 'start from timestamp' configuration option

Manually tested by pulling my local branch into the stream-replicator project. Ideally we'd set up a better test rig in this repo, but I feel that's better done as part of the further planned work on this library, since it could get quite involved.