### PR TITLE
Add iterator type configuration

### DIFF
--- a/config.go
+++ b/config.go
@@ -4,6 +4,8 @@ package kinsumer
 
 import (
 	"time"
+
+	ktypes "github.com/aws/aws-sdk-go-v2/service/kinesis/types"
 )
 
 //TODO: Update documentation to include the defaults
@@ -33,10 +35,10 @@ type Config struct {
 
 	// Iterator type to use when starting from an empty checkpoint (no previous sequence number)
 	// Valid values: 
-	//   "" or "TRIM_HORIZON" (default): Start reading from the oldest available record
-	//   "LATEST": Start reading from the newest record (skip existing data)
-	//   "AT_TIMESTAMP": Use iteratorStartTimestamp to specify start position
-	iteratorType string
+	//   ktypes.ShardIteratorTypeTrimHorizon (default): Start reading from the oldest available record
+	//   ktypes.ShardIteratorTypeLatest: Start reading from the newest record (skip existing data)
+	//   ktypes.ShardIteratorTypeAtTimestamp: Use iteratorStartTimestamp to specify start position
+	iteratorType ktypes.ShardIteratorType
 
 	// ---------- [ For the leader (first client alphabetically) ] ----------
 	// Time between leader actions
@@ -74,6 +76,7 @@ func NewConfig() Config {
 		dynamoWriteCapacity:   10,
 		dynamoWaiterDelay:     3 * time.Second,
 		logger:                &DefaultLogger{},
+		iteratorType:          ktypes.ShardIteratorTypeTrimHorizon,
 	}
 }
 
@@ -137,10 +140,10 @@ func (c Config) WithIteratorStartTimestamp(timestamp *time.Time) Config {
 // WithIteratorType returns a Config with a modified iterator type for new checkpoints
 // This determines where to start reading when no previous checkpoint exists.
 // Valid values:
-//   "" or "TRIM_HORIZON" (default): Start from the oldest available record
-//   "LATEST": Start from the newest record (skip all existing data)
-//   "AT_TIMESTAMP": Start from iteratorStartTimestamp (must also call WithIteratorStartTimestamp)
-func (c Config) WithIteratorType(iteratorType string) Config {
+//   ktypes.ShardIteratorTypeTrimHorizon (default): Start from the oldest available record
+//   ktypes.ShardIteratorTypeLatest: Start from the newest record (skip all existing data)
+//   ktypes.ShardIteratorTypeAtTimestamp: Start from iteratorStartTimestamp (must also call WithIteratorStartTimestamp)
+func (c Config) WithIteratorType(iteratorType ktypes.ShardIteratorType) Config {
 	c.iteratorType = iteratorType
 	return c
 }
@@ -217,11 +220,15 @@ func validateConfig(c *Config) error {
 		return ErrConfigInvalidLogger
 	}
 
-	if c.iteratorType != "" && c.iteratorType != "TRIM_HORIZON" && c.iteratorType != "LATEST" && c.iteratorType != "AT_TIMESTAMP" {
+	// Validate iterator type is supported (zero value defaults to TRIM_HORIZON)
+	if c.iteratorType != "" && 
+		c.iteratorType != ktypes.ShardIteratorTypeTrimHorizon && 
+		c.iteratorType != ktypes.ShardIteratorTypeLatest && 
+		c.iteratorType != ktypes.ShardIteratorTypeAtTimestamp {
 		return ErrConfigInvalidIteratorType
 	}
 
-	if c.iteratorType == "AT_TIMESTAMP" && c.iteratorStartTimestamp == nil {
+	if c.iteratorType == ktypes.ShardIteratorTypeAtTimestamp && c.iteratorStartTimestamp == nil {
 		return ErrConfigInvalidIteratorTimestamp
 	}
 

--- a/config.go
+++ b/config.go
@@ -76,7 +76,7 @@ func NewConfig() Config {
 		dynamoWriteCapacity:   10,
 		dynamoWaiterDelay:     3 * time.Second,
 		logger:                &DefaultLogger{},
-		iteratorType:          ktypes.ShardIteratorTypeTrimHorizon,
+		iteratorType:          ktypes.ShardIteratorTypeLatest,
 	}
 }
 
@@ -220,9 +220,8 @@ func validateConfig(c *Config) error {
 		return ErrConfigInvalidLogger
 	}
 
-	// Validate iterator type is supported (zero value defaults to TRIM_HORIZON)
-	if c.iteratorType != "" && 
-		c.iteratorType != ktypes.ShardIteratorTypeTrimHorizon && 
+	// Validate iterator type is supported (empty string not allowed)
+	if c.iteratorType != ktypes.ShardIteratorTypeTrimHorizon && 
 		c.iteratorType != ktypes.ShardIteratorTypeLatest && 
 		c.iteratorType != ktypes.ShardIteratorTypeAtTimestamp {
 		return ErrConfigInvalidIteratorType

--- a/config.go
+++ b/config.go
@@ -31,6 +31,13 @@ type Config struct {
 	// Starting timestamp of the shard iterator, if "AT_TIMESTAMP" is the desired iterator type
 	iteratorStartTimestamp *time.Time
 
+	// Iterator type to use when starting from an empty checkpoint (no previous sequence number)
+	// Valid values: 
+	//   "" or "TRIM_HORIZON" (default): Start reading from the oldest available record
+	//   "LATEST": Start reading from the newest record (skip existing data)
+	//   "AT_TIMESTAMP": Use iteratorStartTimestamp to specify start position
+	iteratorType string
+
 	// ---------- [ For the leader (first client alphabetically) ] ----------
 	// Time between leader actions
 	leaderActionFrequency time.Duration
@@ -127,6 +134,17 @@ func (c Config) WithIteratorStartTimestamp(timestamp *time.Time) Config {
 	return c
 }
 
+// WithIteratorType returns a Config with a modified iterator type for new checkpoints
+// This determines where to start reading when no previous checkpoint exists.
+// Valid values:
+//   "" or "TRIM_HORIZON" (default): Start from the oldest available record
+//   "LATEST": Start from the newest record (skip all existing data)
+//   "AT_TIMESTAMP": Start from iteratorStartTimestamp (must also call WithIteratorStartTimestamp)
+func (c Config) WithIteratorType(iteratorType string) Config {
+	c.iteratorType = iteratorType
+	return c
+}
+
 // WithDynamoReadCapacity returns a Config with a modified dynamo read capacity
 func (c Config) WithDynamoReadCapacity(readCapacity int64) Config {
 	c.dynamoReadCapacity = readCapacity
@@ -197,6 +215,14 @@ func validateConfig(c *Config) error {
 
 	if c.logger == nil {
 		return ErrConfigInvalidLogger
+	}
+
+	if c.iteratorType != "" && c.iteratorType != "TRIM_HORIZON" && c.iteratorType != "LATEST" && c.iteratorType != "AT_TIMESTAMP" {
+		return ErrConfigInvalidIteratorType
+	}
+
+	if c.iteratorType == "AT_TIMESTAMP" && c.iteratorStartTimestamp == nil {
+		return ErrConfigInvalidIteratorTimestamp
 	}
 
 	return nil

--- a/errors.go
+++ b/errors.go
@@ -38,8 +38,8 @@ var (
 	ErrConfigInvalidDynamoCapacity = errors.New("dynamo read/write capacity cannot be 0")
 	// ErrConfigInvalidLogger - Logger cannot be nil
 	ErrConfigInvalidLogger = errors.New("logger cannot be nil")
-	// ErrConfigInvalidIteratorType - Iterator type must be a valid value
-	ErrConfigInvalidIteratorType = errors.New("iteratorType must be one of: TRIM_HORIZON, LATEST, AT_TIMESTAMP")
+	// ErrConfigInvalidIteratorType - Iterator type must be a supported value
+	ErrConfigInvalidIteratorType = errors.New("iteratorType must be one of: ShardIteratorTypeTrimHorizon, ShardIteratorTypeLatest, ShardIteratorTypeAtTimestamp")
 	// ErrConfigInvalidIteratorTimestamp - AT_TIMESTAMP iterator type requires a timestamp
 	ErrConfigInvalidIteratorTimestamp = errors.New("iteratorType AT_TIMESTAMP requires iteratorStartTimestamp to be set")
 

--- a/errors.go
+++ b/errors.go
@@ -38,6 +38,10 @@ var (
 	ErrConfigInvalidDynamoCapacity = errors.New("dynamo read/write capacity cannot be 0")
 	// ErrConfigInvalidLogger - Logger cannot be nil
 	ErrConfigInvalidLogger = errors.New("logger cannot be nil")
+	// ErrConfigInvalidIteratorType - Iterator type must be a valid value
+	ErrConfigInvalidIteratorType = errors.New("iteratorType must be one of: TRIM_HORIZON, LATEST, AT_TIMESTAMP")
+	// ErrConfigInvalidIteratorTimestamp - AT_TIMESTAMP iterator type requires a timestamp
+	ErrConfigInvalidIteratorTimestamp = errors.New("iteratorType AT_TIMESTAMP requires iteratorStartTimestamp to be set")
 
 	// ErrStreamBusy - Stream is busy
 	ErrStreamBusy = errors.New("stream is busy")

--- a/shard_consumer.go
+++ b/shard_consumer.go
@@ -33,15 +33,17 @@ func getShardIterator(k kinsumeriface.KinesisAPI, streamName string, shardID str
 	if sequenceNumber == "" {
 		// Use configured iterator type for new checkpoints
 		switch iteratorType {
+		case ktypes.ShardIteratorTypeTrimHorizon:
+			shardIteratorType = ktypes.ShardIteratorTypeTrimHorizon
+			ps = nil
 		case ktypes.ShardIteratorTypeLatest:
 			shardIteratorType = ktypes.ShardIteratorTypeLatest
 			ps = nil
 		case ktypes.ShardIteratorTypeAtTimestamp:
 			shardIteratorType = ktypes.ShardIteratorTypeAtTimestamp
 			ps = nil
-		default: // ktypes.ShardIteratorTypeTrimHorizon or empty
-			shardIteratorType = ktypes.ShardIteratorTypeTrimHorizon
-			ps = nil
+		default:
+			return "", fmt.Errorf("unsupported iterator type: %v", iteratorType)
 		}
 	} else if sequenceNumber == "LATEST" {
 		// Backward compatibility: support "LATEST" as sequence number

--- a/shard_consumer.go
+++ b/shard_consumer.go
@@ -23,8 +23,8 @@ const (
 )
 
 // getShardIterator gets a shard iterator after the last sequence number we read or at the start of the stream
-// iteratorType specifies the type to use when sequenceNumber is empty: "TRIM_HORIZON" (default), "LATEST", or "AT_TIMESTAMP"
-func getShardIterator(k kinsumeriface.KinesisAPI, streamName string, shardID string, sequenceNumber string, iteratorStartTimestamp *time.Time, iteratorType string) (string, error) {
+// iteratorType specifies the type to use when sequenceNumber is empty
+func getShardIterator(k kinsumeriface.KinesisAPI, streamName string, shardID string, sequenceNumber string, iteratorStartTimestamp *time.Time, iteratorType ktypes.ShardIteratorType) (string, error) {
 	shardIteratorType := ktypes.ShardIteratorTypeAfterSequenceNumber
 
 	// If we do not have a sequenceNumber yet we need to get a shardIterator
@@ -33,13 +33,13 @@ func getShardIterator(k kinsumeriface.KinesisAPI, streamName string, shardID str
 	if sequenceNumber == "" {
 		// Use configured iterator type for new checkpoints
 		switch iteratorType {
-		case "LATEST":
+		case ktypes.ShardIteratorTypeLatest:
 			shardIteratorType = ktypes.ShardIteratorTypeLatest
 			ps = nil
-		case "AT_TIMESTAMP":
+		case ktypes.ShardIteratorTypeAtTimestamp:
 			shardIteratorType = ktypes.ShardIteratorTypeAtTimestamp
 			ps = nil
-		default: // "" or "TRIM_HORIZON"
+		default: // ktypes.ShardIteratorTypeTrimHorizon or empty
 			shardIteratorType = ktypes.ShardIteratorTypeTrimHorizon
 			ps = nil
 		}

--- a/shard_consumer.go
+++ b/shard_consumer.go
@@ -23,19 +23,28 @@ const (
 )
 
 // getShardIterator gets a shard iterator after the last sequence number we read or at the start of the stream
-func getShardIterator(k kinsumeriface.KinesisAPI, streamName string, shardID string, sequenceNumber string, iteratorStartTimestamp *time.Time) (string, error) {
+// iteratorType specifies the type to use when sequenceNumber is empty: "TRIM_HORIZON" (default), "LATEST", or "AT_TIMESTAMP"
+func getShardIterator(k kinsumeriface.KinesisAPI, streamName string, shardID string, sequenceNumber string, iteratorStartTimestamp *time.Time, iteratorType string) (string, error) {
 	shardIteratorType := ktypes.ShardIteratorTypeAfterSequenceNumber
 
 	// If we do not have a sequenceNumber yet we need to get a shardIterator
-	// from the horizon
+	// based on the configured iterator type
 	ps := aws.String(sequenceNumber)
-	if sequenceNumber == "" && iteratorStartTimestamp != nil {
-		shardIteratorType = ktypes.ShardIteratorTypeAtTimestamp
-		ps = nil
-	} else if sequenceNumber == "" {
-		shardIteratorType = ktypes.ShardIteratorTypeTrimHorizon
-		ps = nil
+	if sequenceNumber == "" {
+		// Use configured iterator type for new checkpoints
+		switch iteratorType {
+		case "LATEST":
+			shardIteratorType = ktypes.ShardIteratorTypeLatest
+			ps = nil
+		case "AT_TIMESTAMP":
+			shardIteratorType = ktypes.ShardIteratorTypeAtTimestamp
+			ps = nil
+		default: // "" or "TRIM_HORIZON"
+			shardIteratorType = ktypes.ShardIteratorTypeTrimHorizon
+			ps = nil
+		}
 	} else if sequenceNumber == "LATEST" {
+		// Backward compatibility: support "LATEST" as sequence number
 		shardIteratorType = ktypes.ShardIteratorTypeLatest
 		ps = nil
 	}
@@ -143,7 +152,7 @@ func (k *Kinsumer) consume(shardID string) {
 	}()
 
 	// Get the starting shard iterator
-	iterator, err := getShardIterator(k.kinesis, k.streamName, shardID, sequenceNumber, k.config.iteratorStartTimestamp)
+	iterator, err := getShardIterator(k.kinesis, k.streamName, shardID, sequenceNumber, k.config.iteratorStartTimestamp, k.config.iteratorType)
 	if err != nil {
 		k.shardErrors <- shardConsumerError{shardID: shardID, action: "getShardIterator", err: err}
 		return
@@ -201,7 +210,7 @@ mainloop:
 				var eie *ktypes.ExpiredIteratorException
 				if errors.As(err, &eie) {
 					k.config.logger.Log("Got error: %s %s %s", eie.ErrorCode(), eie.ErrorMessage(), origErrStr)
-					newIterator, ierr := getShardIterator(k.kinesis, k.streamName, shardID, lastSeqToCheckp, nil)
+					newIterator, ierr := getShardIterator(k.kinesis, k.streamName, shardID, lastSeqToCheckp, nil, k.config.iteratorType)
 					if ierr != nil {
 						k.shardErrors <- shardConsumerError{shardID: shardID, action: "getShardIterator", err: err}
 						return

--- a/shard_consumer_test.go
+++ b/shard_consumer_test.go
@@ -2,11 +2,12 @@ package kinsumer
 
 import (
 	"fmt"
-	"github.com/twitchscience/kinsumer/kinsumeriface"
 	"strconv"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/twitchscience/kinsumer/kinsumeriface"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis"
@@ -33,10 +34,13 @@ func TestShardConsumer(t *testing.T) {
 	err := setupTestEnvironment(t, k, dynamo, streamName, 1)
 	require.NoError(t, err, "Problems setting up the test environment")
 
-	config := NewConfig().WithBufferSize(1000)
-	config = config.WithShardCheckFrequency(500 * time.Millisecond)
-	config = config.WithLeaderActionFrequency(500 * time.Millisecond)
+	config := NewConfig().
+		WithBufferSize(1000).
+		WithShardCheckFrequency(500 * time.Millisecond).
+		WithLeaderActionFrequency(500 * time.Millisecond).
+		WithIteratorType(types.ShardIteratorTypeTrimHorizon)
 	kinsumer1, err := NewWithInterfaces(k, dynamo, streamName, *applicationName, "client_1", "", config)
+	require.NoError(t, err)
 
 	desc, err := k.DescribeStream(t.Context(), &kinesis.DescribeStreamInput{
 		StreamName: &streamName,
@@ -74,10 +78,12 @@ func TestForcefulOwnershipChange(t *testing.T) {
 	require.NoError(t, err, "Problems setting up the test environment")
 
 	// Create two kinsumer instances, but don't call run
-	config := NewConfig().WithBufferSize(1000)
-	config = config.WithShardCheckFrequency(500 * time.Millisecond)
-	config = config.WithLeaderActionFrequency(500 * time.Millisecond)
-	config = config.WithCommitFrequency(100 * time.Millisecond)
+	config := NewConfig().
+		WithBufferSize(1000).
+		WithShardCheckFrequency(500 * time.Millisecond).
+		WithLeaderActionFrequency(500 * time.Millisecond).
+		WithCommitFrequency(100 * time.Millisecond).
+		WithIteratorType(types.ShardIteratorTypeTrimHorizon)
 
 	// Set vastly different max ages to synthetically create a forced ownership change
 	maxAge1 := 10 * time.Second
@@ -216,10 +222,12 @@ func TestPotentialLegitimateDuplicates(t *testing.T) {
 	require.NoError(t, err, "Problems setting up the test environment")
 
 	// Create two kinsumer instances, but don't call run
-	config := NewConfig().WithBufferSize(1000)
-	config = config.WithShardCheckFrequency(500 * time.Millisecond)
-	config = config.WithLeaderActionFrequency(500 * time.Millisecond)
-	config = config.WithCommitFrequency(100 * time.Millisecond)
+	config := NewConfig().
+		WithBufferSize(1000).
+		WithShardCheckFrequency(500 * time.Millisecond).
+		WithLeaderActionFrequency(500 * time.Millisecond).
+		WithCommitFrequency(100 * time.Millisecond).
+		WithIteratorType(types.ShardIteratorTypeTrimHorizon)
 
 	// Set vastly different max ages to synthetically create a forced ownership change
 	maxAge1 := 10 * time.Second
@@ -229,7 +237,9 @@ func TestPotentialLegitimateDuplicates(t *testing.T) {
 	config2 := config.WithClientRecordMaxAge(&maxAge2)
 
 	kinsumer1, err := NewWithInterfaces(k, dynamo, streamName, *applicationName, "client_1", "", config1)
+	require.NoError(t, err)
 	kinsumer2, err := NewWithInterfaces(k, dynamo, streamName, *applicationName, "client_2", "", config2)
+	require.NoError(t, err)
 
 	desc, err := k.DescribeStream(t.Context(), &kinesis.DescribeStreamInput{
 		StreamName: &streamName,
@@ -347,14 +357,19 @@ func TestShardsMerged(t *testing.T) {
 	require.NoError(t, err, "Problems setting up the test environment")
 
 	// Create two kinsumer instances, but don't call run
-	config := NewConfig().WithBufferSize(1000)
-	config = config.WithShardCheckFrequency(500 * time.Millisecond)
-	config = config.WithLeaderActionFrequency(500 * time.Millisecond)
-	config = config.WithCommitFrequency(100 * time.Millisecond)
+	config := NewConfig().
+		WithBufferSize(1000).
+		WithShardCheckFrequency(500 * time.Millisecond).
+		WithLeaderActionFrequency(500 * time.Millisecond).
+		WithCommitFrequency(100 * time.Millisecond).
+		WithIteratorType(types.ShardIteratorTypeTrimHorizon)
 
 	kinsumer1, err := NewWithInterfaces(k, dynamo, streamName, *applicationName, "client_1", "", config)
+	require.NoError(t, err)
 	kinsumer2, err := NewWithInterfaces(k, dynamo, streamName, *applicationName, "client_2", "", config)
+	require.NoError(t, err)
 	kinsumer3, err := NewWithInterfaces(k, dynamo, streamName, *applicationName, "client_3", "", config)
+	require.NoError(t, err)
 
 	desc, err := k.DescribeStream(t.Context(), &kinesis.DescribeStreamInput{
 		StreamName: &streamName,
@@ -520,12 +535,15 @@ func TestConsumerStopStart(t *testing.T) {
 	require.NoError(t, err, "Problems setting up the test environment")
 
 	// Create two kinsumer instances, but don't call run
-	config := NewConfig().WithBufferSize(1000)
-	config = config.WithShardCheckFrequency(500 * time.Millisecond)
-	config = config.WithLeaderActionFrequency(500 * time.Millisecond)
-	config = config.WithCommitFrequency(50 * time.Millisecond)
+	config := NewConfig().
+		WithBufferSize(1000).
+		WithShardCheckFrequency(500 * time.Millisecond).
+		WithLeaderActionFrequency(500 * time.Millisecond).
+		WithCommitFrequency(50 * time.Millisecond).
+		WithIteratorType(types.ShardIteratorTypeTrimHorizon)
 
 	kinsumer, err := NewWithInterfaces(k, dynamo, streamName, *applicationName, "client_1", "", config)
+	require.NoError(t, err)
 
 	desc, err := k.DescribeStream(t.Context(), &kinesis.DescribeStreamInput{
 		StreamName: &streamName,
@@ -592,14 +610,19 @@ func TestMultipleConsumerStopStart(t *testing.T) {
 	require.NoError(t, err, "Problems setting up the test environment")
 
 	// Create two kinsumer instances, but don't call run
-	config := NewConfig().WithBufferSize(1000)
-	config = config.WithShardCheckFrequency(500 * time.Millisecond)
-	config = config.WithLeaderActionFrequency(500 * time.Millisecond)
-	config = config.WithCommitFrequency(50 * time.Millisecond)
+	config := NewConfig().
+		WithBufferSize(1000).
+		WithShardCheckFrequency(500 * time.Millisecond).
+		WithLeaderActionFrequency(500 * time.Millisecond).
+		WithCommitFrequency(50 * time.Millisecond).
+		WithIteratorType(types.ShardIteratorTypeTrimHorizon)
 
 	kinsumer1, err := NewWithInterfaces(k, dynamo, streamName, *applicationName, "client_1", "", config)
+	require.NoError(t, err)
 	kinsumer2, err := NewWithInterfaces(k, dynamo, streamName, *applicationName, "client_2", "", config)
+	require.NoError(t, err)
 	kinsumer3, err := NewWithInterfaces(k, dynamo, streamName, *applicationName, "client_3", "", config)
+	require.NoError(t, err)
 
 	desc, err := k.DescribeStream(t.Context(), &kinesis.DescribeStreamInput{
 		StreamName: &streamName,
@@ -715,12 +738,15 @@ func TestDelayedUpdateDuplicates(t *testing.T) {
 	require.NoError(t, err, "Problems setting up the test environment")
 
 	// Create two kinsumer instances, but don't call run
-	config := NewConfig().WithBufferSize(1000)
-	config = config.WithShardCheckFrequency(500 * time.Millisecond)
-	config = config.WithLeaderActionFrequency(500 * time.Millisecond)
-	config = config.WithCommitFrequency(50 * time.Millisecond)
+	config := NewConfig().
+		WithBufferSize(1000).
+		WithShardCheckFrequency(500 * time.Millisecond).
+		WithLeaderActionFrequency(500 * time.Millisecond).
+		WithCommitFrequency(50 * time.Millisecond).
+		WithIteratorType(types.ShardIteratorTypeTrimHorizon)
 
 	kinsumer, err := NewWithInterfaces(k, dynamo, streamName, *applicationName, "client_1", "", config)
+	require.NoError(t, err)
 
 	desc, err := k.DescribeStream(t.Context(), &kinesis.DescribeStreamInput{
 		StreamName: &streamName,


### PR DESCRIPTION
This PR adds a new optional setting - iteratorType.

This allows us to configure LATEST iterator type via the kinsumer configuration, where it was only possible before by manipulating dynamo db directly.

There is a change in behaviour in that to use start tstamp, we must now set iterator type to AT_TIMESTAMP, rather than simply providing the timestamp. If a timestamp is provided without an iterator type, we will fail the configuration validation check.

There are no other changes to behaviour.
