### PR TITLE
Add getRecordsLimit to make pulls configurable

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ type Config struct {
 	iteratorStartTimestamp *time.Time
 
 	// Iterator type to use when starting from an empty checkpoint (no previous sequence number)
-	// Valid values: 
+	// Valid values:
 	//   ktypes.ShardIteratorTypeTrimHorizon (default): Start reading from the oldest available record
 	//   ktypes.ShardIteratorTypeLatest: Start reading from the newest record (skip existing data)
 	//   ktypes.ShardIteratorTypeAtTimestamp: Use iteratorStartTimestamp to specify start position
@@ -61,6 +61,11 @@ type Config struct {
 
 	// use ListShards to avoid LimitExceedException from DescribeStream
 	useListShardsForKinesisStreamReady bool
+
+	// Maximum number of records to fetch per GetRecords request
+	// AWS Kinesis allows up to 10,000 records per request (default)
+	// Reducing this value helps control memory usage at the cost of increased API calls
+	getRecordsLimit int
 }
 
 // NewConfig returns a default Config struct
@@ -77,6 +82,7 @@ func NewConfig() Config {
 		dynamoWaiterDelay:     3 * time.Second,
 		logger:                &DefaultLogger{},
 		iteratorType:          ktypes.ShardIteratorTypeLatest,
+		getRecordsLimit:       10000,
 	}
 }
 
@@ -140,9 +146,10 @@ func (c Config) WithIteratorStartTimestamp(timestamp *time.Time) Config {
 // WithIteratorType returns a Config with a modified iterator type for new checkpoints
 // This determines where to start reading when no previous checkpoint exists.
 // Valid values:
-//   ktypes.ShardIteratorTypeTrimHorizon (default): Start from the oldest available record
-//   ktypes.ShardIteratorTypeLatest: Start from the newest record (skip all existing data)
-//   ktypes.ShardIteratorTypeAtTimestamp: Start from iteratorStartTimestamp (must also call WithIteratorStartTimestamp)
+//
+//	ktypes.ShardIteratorTypeTrimHorizon (default): Start from the oldest available record
+//	ktypes.ShardIteratorTypeLatest: Start from the newest record (skip all existing data)
+//	ktypes.ShardIteratorTypeAtTimestamp: Start from iteratorStartTimestamp (must also call WithIteratorStartTimestamp)
 func (c Config) WithIteratorType(iteratorType ktypes.ShardIteratorType) Config {
 	c.iteratorType = iteratorType
 	return c
@@ -175,6 +182,14 @@ func (c Config) WithLogger(logger Logger) Config {
 // WithUseListShardsForKinesisStreamReady returns a config with a modified useListShardsForKinesisStreamReady toggle
 func (c Config) WithUseListShardsForKinesisStreamReady(shouldUse bool) Config {
 	c.useListShardsForKinesisStreamReady = shouldUse
+	return c
+}
+
+// WithGetRecordsLimit returns a Config with a modified maximum records per GetRecords request
+// This controls how many records to fetch per GetRecords API call.
+// AWS Kinesis allows up to 10,000 records per request. Reducing this helps control memory usage.
+func (c Config) WithGetRecordsLimit(getRecordsLimit int) Config {
+	c.getRecordsLimit = getRecordsLimit
 	return c
 }
 
@@ -221,14 +236,18 @@ func validateConfig(c *Config) error {
 	}
 
 	// Validate iterator type is supported (empty string not allowed)
-	if c.iteratorType != ktypes.ShardIteratorTypeTrimHorizon && 
-		c.iteratorType != ktypes.ShardIteratorTypeLatest && 
+	if c.iteratorType != ktypes.ShardIteratorTypeTrimHorizon &&
+		c.iteratorType != ktypes.ShardIteratorTypeLatest &&
 		c.iteratorType != ktypes.ShardIteratorTypeAtTimestamp {
 		return ErrConfigInvalidIteratorType
 	}
 
 	if c.iteratorType == ktypes.ShardIteratorTypeAtTimestamp && c.iteratorStartTimestamp == nil {
 		return ErrConfigInvalidIteratorTimestamp
+	}
+
+	if c.getRecordsLimit <= 0 || c.getRecordsLimit > 10000 {
+		return ErrConfigInvalidGetRecordsLimit
 	}
 
 	return nil

--- a/errors.go
+++ b/errors.go
@@ -42,6 +42,8 @@ var (
 	ErrConfigInvalidIteratorType = errors.New("iteratorType must be one of: ShardIteratorTypeTrimHorizon, ShardIteratorTypeLatest, ShardIteratorTypeAtTimestamp")
 	// ErrConfigInvalidIteratorTimestamp - AT_TIMESTAMP iterator type requires a timestamp
 	ErrConfigInvalidIteratorTimestamp = errors.New("iteratorType AT_TIMESTAMP requires iteratorStartTimestamp to be set")
+	// ErrConfigInvalidGetRecordsLimit - getRecordsLimit must be between 1 and 10000
+	ErrConfigInvalidGetRecordsLimit = errors.New("getRecordsLimit must be between 1 and 10000")
 
 	// ErrStreamBusy - Stream is busy
 	ErrStreamBusy = errors.New("stream is busy")

--- a/shard_consumer.go
+++ b/shard_consumer.go
@@ -15,12 +15,6 @@ import (
 	smithy "github.com/aws/smithy-go"
 )
 
-const (
-	// getRecordsLimit is the max number of records in a single request. This effectively limits the
-	// total processing speed to getRecordsLimit*5/n where n is the number of parallel clients trying
-	// to consume from the same kinesis stream
-	getRecordsLimit = 10000 // 10,000 is the max according to the docs
-)
 
 // getShardIterator gets a shard iterator after the last sequence number we read or at the start of the stream
 // iteratorType specifies the type to use when sequenceNumber is empty
@@ -65,9 +59,9 @@ func getShardIterator(k kinsumeriface.KinesisAPI, streamName string, shardID str
 }
 
 // getRecords returns the next records and shard iterator from the given shard iterator
-func getRecords(k kinsumeriface.KinesisAPI, iterator string) (records []ktypes.Record, nextIterator string, lag time.Duration, err error) {
+func getRecords(k kinsumeriface.KinesisAPI, iterator string, limit int) (records []ktypes.Record, nextIterator string, lag time.Duration, err error) {
 	params := &kinesis.GetRecordsInput{
-		Limit:         aws.Int32(getRecordsLimit),
+		Limit:         aws.Int32(int32(limit)),
 		ShardIterator: aws.String(iterator),
 	}
 
@@ -201,7 +195,7 @@ mainloop:
 		}
 
 		// Get records from kinesis
-		records, next, lag, err := getRecords(k.kinesis, iterator)
+		records, next, lag, err := getRecords(k.kinesis, iterator, k.config.getRecordsLimit)
 
 		if err != nil {
 			var ae smithy.APIError


### PR DESCRIPTION
(made this PR into the branch it's based off, but it'll get rebased to go into release/1.7.0 once that one's merged)

For each shard, we spawn a goroutine to consume data via get requests. This PR adds a configuration to determine the maximum number of records each get request pulls.

We will use this to limit the memory overhead when there's a bottleneck.