### PR TITLE
Fix Shard Iterator logic

### DIFF
--- a/config.go
+++ b/config.go
@@ -4,6 +4,8 @@ package kinsumer
 
 import (
 	"time"
+
+	ktypes "github.com/aws/aws-sdk-go-v2/service/kinesis/types"
 )
 
 //TODO: Update documentation to include the defaults
@@ -30,6 +32,13 @@ type Config struct {
 
 	// Starting timestamp of the shard iterator, if "AT_TIMESTAMP" is the desired iterator type
 	iteratorStartTimestamp *time.Time
+
+	// Iterator type to use when starting from an empty checkpoint (no previous sequence number)
+	// Valid values: 
+	//   ktypes.ShardIteratorTypeTrimHorizon (default): Start reading from the oldest available record
+	//   ktypes.ShardIteratorTypeLatest: Start reading from the newest record (skip existing data)
+	//   ktypes.ShardIteratorTypeAtTimestamp: Use iteratorStartTimestamp to specify start position
+	iteratorType ktypes.ShardIteratorType
 
 	// ---------- [ For the leader (first client alphabetically) ] ----------
 	// Time between leader actions
@@ -67,6 +76,7 @@ func NewConfig() Config {
 		dynamoWriteCapacity:   10,
 		dynamoWaiterDelay:     3 * time.Second,
 		logger:                &DefaultLogger{},
+		iteratorType:          ktypes.ShardIteratorTypeLatest,
 	}
 }
 
@@ -124,6 +134,17 @@ func (c Config) WithStats(stats StatReceiver) Config {
 // WithIteratorStartTimestamp returns a Config with a modified iteratorStartTimestamp
 func (c Config) WithIteratorStartTimestamp(timestamp *time.Time) Config {
 	c.iteratorStartTimestamp = timestamp
+	return c
+}
+
+// WithIteratorType returns a Config with a modified iterator type for new checkpoints
+// This determines where to start reading when no previous checkpoint exists.
+// Valid values:
+//   ktypes.ShardIteratorTypeTrimHorizon (default): Start from the oldest available record
+//   ktypes.ShardIteratorTypeLatest: Start from the newest record (skip all existing data)
+//   ktypes.ShardIteratorTypeAtTimestamp: Start from iteratorStartTimestamp (must also call WithIteratorStartTimestamp)
+func (c Config) WithIteratorType(iteratorType ktypes.ShardIteratorType) Config {
+	c.iteratorType = iteratorType
 	return c
 }
 
@@ -197,6 +218,17 @@ func validateConfig(c *Config) error {
 
 	if c.logger == nil {
 		return ErrConfigInvalidLogger
+	}
+
+	// Validate iterator type is supported (empty string not allowed)
+	if c.iteratorType != ktypes.ShardIteratorTypeTrimHorizon && 
+		c.iteratorType != ktypes.ShardIteratorTypeLatest && 
+		c.iteratorType != ktypes.ShardIteratorTypeAtTimestamp {
+		return ErrConfigInvalidIteratorType
+	}
+
+	if c.iteratorType == ktypes.ShardIteratorTypeAtTimestamp && c.iteratorStartTimestamp == nil {
+		return ErrConfigInvalidIteratorTimestamp
 	}
 
 	return nil

--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ type Config struct {
 	iteratorStartTimestamp *time.Time
 
 	// Iterator type to use when starting from an empty checkpoint (no previous sequence number)
-	// Valid values: 
+	// Valid values:
 	//   ktypes.ShardIteratorTypeTrimHorizon (default): Start reading from the oldest available record
 	//   ktypes.ShardIteratorTypeLatest: Start reading from the newest record (skip existing data)
 	//   ktypes.ShardIteratorTypeAtTimestamp: Use iteratorStartTimestamp to specify start position
@@ -61,6 +61,11 @@ type Config struct {
 
 	// use ListShards to avoid LimitExceedException from DescribeStream
 	useListShardsForKinesisStreamReady bool
+
+	// Maximum number of records to fetch per GetRecords request
+	// AWS Kinesis allows up to 10,000 records per request (default)
+	// Reducing this value helps control memory usage at the cost of increased API calls
+	getRecordsLimit int
 }
 
 // NewConfig returns a default Config struct
@@ -77,6 +82,7 @@ func NewConfig() Config {
 		dynamoWaiterDelay:     3 * time.Second,
 		logger:                &DefaultLogger{},
 		iteratorType:          ktypes.ShardIteratorTypeLatest,
+		getRecordsLimit:       10000,
 	}
 }
 
@@ -140,9 +146,10 @@ func (c Config) WithIteratorStartTimestamp(timestamp *time.Time) Config {
 // WithIteratorType returns a Config with a modified iterator type for new checkpoints
 // This determines where to start reading when no previous checkpoint exists.
 // Valid values:
-//   ktypes.ShardIteratorTypeTrimHorizon (default): Start from the oldest available record
-//   ktypes.ShardIteratorTypeLatest: Start from the newest record (skip all existing data)
-//   ktypes.ShardIteratorTypeAtTimestamp: Start from iteratorStartTimestamp (must also call WithIteratorStartTimestamp)
+//
+//	ktypes.ShardIteratorTypeTrimHorizon (default): Start from the oldest available record
+//	ktypes.ShardIteratorTypeLatest: Start from the newest record (skip all existing data)
+//	ktypes.ShardIteratorTypeAtTimestamp: Start from iteratorStartTimestamp (must also call WithIteratorStartTimestamp)
 func (c Config) WithIteratorType(iteratorType ktypes.ShardIteratorType) Config {
 	c.iteratorType = iteratorType
 	return c
@@ -175,6 +182,14 @@ func (c Config) WithLogger(logger Logger) Config {
 // WithUseListShardsForKinesisStreamReady returns a config with a modified useListShardsForKinesisStreamReady toggle
 func (c Config) WithUseListShardsForKinesisStreamReady(shouldUse bool) Config {
 	c.useListShardsForKinesisStreamReady = shouldUse
+	return c
+}
+
+// WithGetRecordsLimit returns a Config with a modified maximum records per GetRecords request
+// This controls how many records to fetch per GetRecords API call.
+// AWS Kinesis allows up to 10,000 records per request. Reducing this helps control memory usage.
+func (c Config) WithGetRecordsLimit(getRecordsLimit int) Config {
+	c.getRecordsLimit = getRecordsLimit
 	return c
 }
 
@@ -221,14 +236,18 @@ func validateConfig(c *Config) error {
 	}
 
 	// Validate iterator type is supported (empty string not allowed)
-	if c.iteratorType != ktypes.ShardIteratorTypeTrimHorizon && 
-		c.iteratorType != ktypes.ShardIteratorTypeLatest && 
+	if c.iteratorType != ktypes.ShardIteratorTypeTrimHorizon &&
+		c.iteratorType != ktypes.ShardIteratorTypeLatest &&
 		c.iteratorType != ktypes.ShardIteratorTypeAtTimestamp {
 		return ErrConfigInvalidIteratorType
 	}
 
 	if c.iteratorType == ktypes.ShardIteratorTypeAtTimestamp && c.iteratorStartTimestamp == nil {
 		return ErrConfigInvalidIteratorTimestamp
+	}
+
+	if c.getRecordsLimit <= 0 || c.getRecordsLimit > 10000 {
+		return ErrConfigInvalidGetRecordsLimit
 	}
 
 	return nil

--- a/config.go
+++ b/config.go
@@ -66,6 +66,14 @@ type Config struct {
 	// AWS Kinesis allows up to 10,000 records per request (default)
 	// Reducing this value helps control memory usage at the cost of increased API calls
 	getRecordsLimit int
+	// ---------- [ Memory Management ] ----------
+	// Maximum number of shards that can fetch records from Kinesis concurrently
+	// 0 (default) means unlimited concurrent shards
+	// Setting this helps prevent memory exhaustion during scaling events when a single
+	// client temporarily handles many shards. With random data distribution across shards,
+	// this provides natural fairness over time while controlling peak memory usage.
+	// Example: Setting to 20 limits memory to ~20 * 10k records * avg_record_size
+	maxConcurrentShards int
 }
 
 // NewConfig returns a default Config struct
@@ -193,6 +201,15 @@ func (c Config) WithGetRecordsLimit(getRecordsLimit int) Config {
 	return c
 }
 
+// WithMaxConcurrentShards returns a Config with a modified maximum concurrent shard limit
+// This controls how many shards can fetch records from Kinesis simultaneously.
+// Setting this helps prevent memory pressure during scaling events.
+// 0 (default) means unlimited concurrent shards.
+func (c Config) WithMaxConcurrentShards(maxConcurrentShards int) Config {
+	c.maxConcurrentShards = maxConcurrentShards
+	return c
+}
+
 // Verify that a config struct has sane and valid values
 func validateConfig(c *Config) error {
 	if c.throttleDelay < 200*time.Millisecond {
@@ -248,6 +265,9 @@ func validateConfig(c *Config) error {
 
 	if c.getRecordsLimit <= 0 || c.getRecordsLimit > 10000 {
 		return ErrConfigInvalidGetRecordsLimit
+	}
+	if c.maxConcurrentShards < 0 {
+		return ErrConfigInvalidMaxConcurrentShards
 	}
 
 	return nil

--- a/config_test.go
+++ b/config_test.go
@@ -52,6 +52,10 @@ func TestConfigErrors(t *testing.T) {
 	config = NewConfig().WithStats(nil)
 	err = validateConfig(&config)
 	require.EqualError(t, err, ErrConfigInvalidStats.Error())
+
+	config = NewConfig().WithMaxConcurrentShards(-1)
+	err = validateConfig(&config)
+	require.EqualError(t, err, ErrConfigInvalidMaxConcurrentShards.Error())
 }
 
 func TestConfigWithMethods(t *testing.T) {
@@ -65,7 +69,8 @@ func TestConfigWithMethods(t *testing.T) {
 		WithThrottleDelay(1 * time.Second).
 		WithStats(stats).
 		WithIteratorStartTimestamp(&tstamp).
-		WithUseListShardsForKinesisStreamReady(true)
+		WithUseListShardsForKinesisStreamReady(true).
+		WithMaxConcurrentShards(10)
 
 	err := validateConfig(&config)
 	require.NoError(t, err)
@@ -78,4 +83,5 @@ func TestConfigWithMethods(t *testing.T) {
 	require.Equal(t, stats, config.stats)
 	require.Equal(t, &tstamp, config.iteratorStartTimestamp)
 	require.Equal(t, true, config.useListShardsForKinesisStreamReady)
+	require.Equal(t, 10, config.maxConcurrentShards)
 }

--- a/errors.go
+++ b/errors.go
@@ -42,6 +42,8 @@ var (
 	ErrConfigInvalidIteratorType = errors.New("iteratorType must be one of: ShardIteratorTypeTrimHorizon, ShardIteratorTypeLatest, ShardIteratorTypeAtTimestamp")
 	// ErrConfigInvalidIteratorTimestamp - AT_TIMESTAMP iterator type requires a timestamp
 	ErrConfigInvalidIteratorTimestamp = errors.New("iteratorType AT_TIMESTAMP requires iteratorStartTimestamp to be set")
+	// ErrConfigInvalidGetRecordsLimit - getRecordsLimit must be between 1 and 10000
+	ErrConfigInvalidGetRecordsLimit = errors.New("getRecordsLimit must be between 1 and 10000")
 
 	// ErrStreamBusy - Stream is busy
 	ErrStreamBusy = errors.New("stream is busy")

--- a/errors.go
+++ b/errors.go
@@ -44,6 +44,8 @@ var (
 	ErrConfigInvalidIteratorTimestamp = errors.New("iteratorType AT_TIMESTAMP requires iteratorStartTimestamp to be set")
 	// ErrConfigInvalidGetRecordsLimit - getRecordsLimit must be between 1 and 10000
 	ErrConfigInvalidGetRecordsLimit = errors.New("getRecordsLimit must be between 1 and 10000")
+	// ErrConfigInvalidMaxConcurrentShards - maxConcurrentShards must be >= 0
+	ErrConfigInvalidMaxConcurrentShards = errors.New("maxConcurrentShards must be >= 0")
 
 	// ErrStreamBusy - Stream is busy
 	ErrStreamBusy = errors.New("stream is busy")

--- a/errors.go
+++ b/errors.go
@@ -38,6 +38,10 @@ var (
 	ErrConfigInvalidDynamoCapacity = errors.New("dynamo read/write capacity cannot be 0")
 	// ErrConfigInvalidLogger - Logger cannot be nil
 	ErrConfigInvalidLogger = errors.New("logger cannot be nil")
+	// ErrConfigInvalidIteratorType - Iterator type must be a supported value
+	ErrConfigInvalidIteratorType = errors.New("iteratorType must be one of: ShardIteratorTypeTrimHorizon, ShardIteratorTypeLatest, ShardIteratorTypeAtTimestamp")
+	// ErrConfigInvalidIteratorTimestamp - AT_TIMESTAMP iterator type requires a timestamp
+	ErrConfigInvalidIteratorTimestamp = errors.New("iteratorType AT_TIMESTAMP requires iteratorStartTimestamp to be set")
 
 	// ErrStreamBusy - Stream is busy
 	ErrStreamBusy = errors.New("stream is busy")

--- a/kinsumer.go
+++ b/kinsumer.go
@@ -183,6 +183,8 @@ type Kinsumer struct {
 	maxAgeForLeaderRecord time.Duration           // Cutoff for leader/shard cache records we read from dynamodb before we assume the record is stale
 	shardSemaphore        chan struct{}           // Semaphore to limit concurrent shard record fetching
 	metricsManager        *MetricsManager         // Channel-based metrics manager to avoid atomic contention
+	pendingRecords        int64                   // Accumulated record decrements for batching
+	pendingBytes          int64                   // Accumulated byte decrements for batching
 }
 
 // New returns a Kinsumer Interface with default kinesis and dynamodb instances, to be used in ec2 instances to get default auth and config
@@ -535,6 +537,10 @@ func (k *Kinsumer) Run() error {
 			// Do this outside the k.isLeader check in case k.isLeader was false because
 			// we lost leadership but haven't had time to shutdown the goroutine yet.
 			k.leaderWG.Wait()
+			// Flush any remaining pending metrics before shutdown
+			if k.pendingRecords > 0 || k.pendingBytes > 0 {
+				k.metricsManager.decrementCombined(k.pendingRecords, k.pendingBytes)
+			}
 			// Shutdown metrics goroutine
 			k.metricsManager.shutdown()
 		}()
@@ -584,7 +590,13 @@ func (k *Kinsumer) Run() error {
 				if !k.config.manualCheckpointing {
 					record.checkpointer.update(aws.ToString(record.record.SequenceNumber))
 				}
-				k.metricsManager.decrementCombined(1, record.payloadBytes)
+				k.pendingRecords++
+				k.pendingBytes += record.payloadBytes
+				if k.pendingRecords >= 50 {
+					k.metricsManager.decrementCombined(k.pendingRecords, k.pendingBytes)
+					k.pendingRecords = 0
+					k.pendingBytes = 0
+				}
 				record = nil
 			case se := <-k.shardErrors:
 				k.errors <- fmt.Errorf("shard error (%s) in %s: %s", se.shardID, se.action, se.err)

--- a/kinsumer.go
+++ b/kinsumer.go
@@ -31,6 +31,7 @@ type consumedRecord struct {
 	record       *ktypes.Record // Record retrieved from kinesis
 	checkpointer *checkpointer  // Object that will store the checkpoint back to the database
 	retrievedAt  time.Time      // Time the record was retrieved from Kinesis
+	payloadBytes int64          // Size of record.Data payload in bytes
 }
 
 // Kinsumer is a Kinesis Consumer that tries to reduce duplicate reads while allowing for multiple
@@ -66,6 +67,7 @@ type Kinsumer struct {
 	maxAgeForLeaderRecord time.Duration           // Cutoff for leader/shard cache records we read from dynamodb before we assume the record is stale
 	shardSemaphore        chan struct{}           // Semaphore to limit concurrent shard record fetching
 	recordsInMemoryCount  int64                   // Atomic counter for records pulled from Kinesis but not yet delivered to client
+	bytesInMemoryCount    int64                   // Atomic counter for payload bytes pulled from Kinesis but not yet delivered to client
 }
 
 // New returns a Kinsumer Interface with default kinesis and dynamodb instances, to be used in ec2 instances to get default auth and config
@@ -462,6 +464,7 @@ func (k *Kinsumer) Run() error {
 					record.checkpointer.update(aws.ToString(record.record.SequenceNumber))
 				}
 				atomic.AddInt64(&k.recordsInMemoryCount, -1)
+				atomic.AddInt64(&k.bytesInMemoryCount, -record.payloadBytes)
 				record = nil
 			case se := <-k.shardErrors:
 				k.errors <- fmt.Errorf("shard error (%s) in %s: %s", se.shardID, se.action, se.err)
@@ -491,6 +494,8 @@ func (k *Kinsumer) Run() error {
 			case <-bufferReportTicker.C:
 				// Report the current number of records pulled from Kinesis but not yet delivered to client
 				k.config.stats.RecordsInMemory(int(atomic.LoadInt64(&k.recordsInMemoryCount)))
+				// Report the current total bytes of record payloads pulled from Kinesis but not yet delivered to client
+				k.config.stats.RecordsInMemoryBytes(atomic.LoadInt64(&k.bytesInMemoryCount))
 			}
 		}
 	}()

--- a/kinsumer.go
+++ b/kinsumer.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	dbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis"
@@ -300,9 +301,15 @@ func (k *Kinsumer) refreshShards() (bool, error) {
 	}
 
 	if len(shardIDs) == 0 {
+		// If we haven't yet registered shards, load them from kinesis
 		shardIDs, err = loadShardIDsFromKinesis(k.kinesis, k.streamName)
 		if err == nil {
-			err = k.setCachedShardIDs(shardIDs)
+			// If the iterator type is set to LATEST, we need to maek the checkpoints table as such.
+			err = k.createBootstrapMarkers(shardIDs)
+			if err == nil {
+				// Set the cache only if the previous function succeeded
+				err = k.setCachedShardIDs(shardIDs)
+			}
 		}
 	}
 
@@ -728,6 +735,55 @@ func (k *Kinsumer) NextRecordWithCheckpointer() (rec *ktypes.Record, checkpointe
 	}
 
 	return rec, checkpointer, err
+}
+
+// createBootstrapMarkers creates "LATEST" markers for shards without existing checkpoints
+// This distinguishes true bootstrap scenarios from shard scaling operations
+func (k *Kinsumer) createBootstrapMarkers(shardIDs []string) error {
+	// Only create bootstrap markers if configured iterator type is LATEST
+	if k.config.iteratorType != ktypes.ShardIteratorTypeLatest {
+		return nil
+	}
+
+	// Load existing checkpoints to see which shards already have records
+	checkpoints, err := loadCheckpoints(k.dynamodb, k.checkpointTableName)
+	if err != nil {
+		return fmt.Errorf("error loading existing checkpoints: %v", err)
+	}
+
+	now := time.Now()
+	// Create bootstrap markers for shards without existing checkpoints
+	for _, shardID := range shardIDs {
+		// Skip shards that already have checkpoints
+		if _, exists := checkpoints[shardID]; exists {
+			continue
+		}
+
+		// Create bootstrap marker with "LATEST" as sequence number
+		record := checkpointRecord{
+			Shard:          shardID,
+			SequenceNumber: aws.String("LATEST"), // Bootstrap marker
+			LastUpdate:     now.UnixNano(),
+			LastUpdateRFC:  now.UTC().Format(time.RFC1123Z),
+			// Leave OwnerID and OwnerName as nil for bootstrap markers
+		}
+
+		item, err := attributevalue.MarshalMap(record)
+		if err != nil {
+			return fmt.Errorf("error marshalling bootstrap marker for shard %s: %v", shardID, err)
+		}
+
+		// Use unconditional PutItem to avoid race condition issues
+		_, err = k.dynamodb.PutItem(context.Background(), &dynamodb.PutItemInput{
+			TableName: aws.String(k.checkpointTableName),
+			Item:      item,
+		})
+		if err != nil {
+			return fmt.Errorf("error writing bootstrap marker for shard %s: %v", shardID, err)
+		}
+	}
+
+	return nil
 }
 
 // CreateRequiredTables will create the required dynamodb tables

--- a/kinsumer.go
+++ b/kinsumer.go
@@ -64,6 +64,7 @@ type Kinsumer struct {
 	leaderWG              sync.WaitGroup          // waitGroup for the leader loop
 	maxAgeForClientRecord time.Duration           // Cutoff for client/checkpoint records we read from dynamodb before we assume the record is stale
 	maxAgeForLeaderRecord time.Duration           // Cutoff for leader/shard cache records we read from dynamodb before we assume the record is stale
+	shardSemaphore        chan struct{}           // Semaphore to limit concurrent shard record fetching
 }
 
 // New returns a Kinsumer Interface with default kinesis and dynamodb instances, to be used in ec2 instances to get default auth and config
@@ -132,6 +133,11 @@ func NewWithInterfaces(
 		config:                config,
 		maxAgeForClientRecord: *config.clientRecordMaxAge,
 		maxAgeForLeaderRecord: config.leaderActionFrequency * 5,
+	}
+
+	// Initialize semaphore for limiting concurrent shard record fetching
+	if config.maxConcurrentShards > 0 {
+		consumer.shardSemaphore = make(chan struct{}, config.maxConcurrentShards)
 	}
 	return consumer, nil
 }

--- a/kinsumer.go
+++ b/kinsumer.go
@@ -424,6 +424,12 @@ func (k *Kinsumer) Run() error {
 			shardChangeTicker.Stop()
 		}()
 
+		// Report buffer size every 5 seconds
+		bufferReportTicker := time.NewTicker(5 * time.Second)
+		defer func() {
+			bufferReportTicker.Stop()
+		}()
+
 		var record *consumedRecord
 		if err := k.startConsumers(); err != nil {
 			k.errors <- fmt.Errorf("error starting consumers: %s", err)
@@ -480,6 +486,9 @@ func (k *Kinsumer) Run() error {
 
 					k.isRestartingConsumers = false
 				}
+			case <-bufferReportTicker.C:
+				// Report the current number of records buffered in memory
+				k.config.stats.RecordsInMemory(len(k.records))
 			}
 		}
 	}()

--- a/kinsumer.go
+++ b/kinsumer.go
@@ -34,6 +34,86 @@ type consumedRecord struct {
 	payloadBytes int64          // Size of record.Data payload in bytes
 }
 
+// MetricType represents the type of metric update
+type MetricType int
+
+const (
+	RecordsIncrement MetricType = iota
+	RecordsDecrement
+	BytesIncrement
+	BytesDecrement
+)
+
+// MetricUpdate represents a single metric update to be processed
+type MetricUpdate struct {
+	Type  MetricType
+	Value int64
+}
+
+// MetricsManager handles metrics updates through channels to avoid atomic contention
+type MetricsManager struct {
+	updates      chan MetricUpdate
+	stop         chan struct{}
+	recordsCount int64 // Current records count - only written by metrics goroutine
+	bytesCount   int64 // Current bytes count - only written by metrics goroutine
+}
+
+// newMetricsManager creates a new MetricsManager with buffered channel
+func newMetricsManager() *MetricsManager {
+	return &MetricsManager{
+		updates: make(chan MetricUpdate, 50000), // Large buffer to handle bursts
+		stop:    make(chan struct{}),
+	}
+}
+
+// updateMetric sends a non-blocking metric update
+func (mm *MetricsManager) updateMetric(t MetricType, value int64) {
+	select {
+	case mm.updates <- MetricUpdate{Type: t, Value: value}:
+		// Successfully queued
+	default:
+		// Channel full - drop metric to avoid blocking hot path
+	}
+}
+
+// getCurrentMetrics returns current metric values using atomic loads
+func (mm *MetricsManager) getCurrentMetrics() (int64, int64) {
+	return atomic.LoadInt64(&mm.recordsCount), atomic.LoadInt64(&mm.bytesCount)
+}
+
+// run processes metric updates in a separate goroutine
+func (mm *MetricsManager) run() {
+	var recordsCount, bytesCount int64
+
+	for {
+		select {
+		case update := <-mm.updates:
+			switch update.Type {
+			case RecordsIncrement:
+				recordsCount += update.Value
+			case RecordsDecrement:
+				recordsCount -= update.Value
+			case BytesIncrement:
+				bytesCount += update.Value
+			case BytesDecrement:
+				bytesCount -= update.Value
+			}
+
+			// Update shared state - single writer, no contention
+			atomic.StoreInt64(&mm.recordsCount, recordsCount)
+			atomic.StoreInt64(&mm.bytesCount, bytesCount)
+
+		case <-mm.stop:
+			return
+		}
+	}
+}
+
+// shutdown stops the metrics goroutine
+func (mm *MetricsManager) shutdown() {
+	close(mm.stop)
+}
+
 // Kinsumer is a Kinesis Consumer that tries to reduce duplicate reads while allowing for multiple
 // clients each processing multiple shards
 type Kinsumer struct {
@@ -66,8 +146,7 @@ type Kinsumer struct {
 	maxAgeForClientRecord time.Duration           // Cutoff for client/checkpoint records we read from dynamodb before we assume the record is stale
 	maxAgeForLeaderRecord time.Duration           // Cutoff for leader/shard cache records we read from dynamodb before we assume the record is stale
 	shardSemaphore        chan struct{}           // Semaphore to limit concurrent shard record fetching
-	recordsInMemoryCount  int64                   // Atomic counter for records pulled from Kinesis but not yet delivered to client
-	bytesInMemoryCount    int64                   // Atomic counter for payload bytes pulled from Kinesis but not yet delivered to client
+	metricsManager        *MetricsManager         // Channel-based metrics manager to avoid atomic contention
 }
 
 // New returns a Kinsumer Interface with default kinesis and dynamodb instances, to be used in ec2 instances to get default auth and config
@@ -136,6 +215,7 @@ func NewWithInterfaces(
 		config:                config,
 		maxAgeForClientRecord: *config.clientRecordMaxAge,
 		maxAgeForLeaderRecord: config.leaderActionFrequency * 5,
+		metricsManager:        newMetricsManager(),
 	}
 
 	// Initialize semaphore for limiting concurrent shard record fetching
@@ -401,6 +481,9 @@ func (k *Kinsumer) Run() error {
 		return fmt.Errorf("error in kinsumer Run initial refreshShards: %v", err)
 	}
 
+	// Start metrics goroutine
+	go k.metricsManager.run()
+
 	k.mainWG.Add(1)
 	go func() {
 		defer k.mainWG.Done()
@@ -416,6 +499,8 @@ func (k *Kinsumer) Run() error {
 			// Do this outside the k.isLeader check in case k.isLeader was false because
 			// we lost leadership but haven't had time to shutdown the goroutine yet.
 			k.leaderWG.Wait()
+			// Shutdown metrics goroutine
+			k.metricsManager.shutdown()
 		}()
 
 		// We close k.output so that Next() stops, this is also the reason
@@ -463,8 +548,8 @@ func (k *Kinsumer) Run() error {
 				if !k.config.manualCheckpointing {
 					record.checkpointer.update(aws.ToString(record.record.SequenceNumber))
 				}
-				atomic.AddInt64(&k.recordsInMemoryCount, -1)
-				atomic.AddInt64(&k.bytesInMemoryCount, -record.payloadBytes)
+				k.metricsManager.updateMetric(RecordsDecrement, 1)
+				k.metricsManager.updateMetric(BytesDecrement, record.payloadBytes)
 				record = nil
 			case se := <-k.shardErrors:
 				k.errors <- fmt.Errorf("shard error (%s) in %s: %s", se.shardID, se.action, se.err)
@@ -493,9 +578,10 @@ func (k *Kinsumer) Run() error {
 				}
 			case <-bufferReportTicker.C:
 				// Report the current number of records pulled from Kinesis but not yet delivered to client
-				k.config.stats.RecordsInMemory(atomic.LoadInt64(&k.recordsInMemoryCount))
+				recordsCount, bytesCount := k.metricsManager.getCurrentMetrics()
+				k.config.stats.RecordsInMemory(recordsCount)
 				// Report the current total bytes of record payloads pulled from Kinesis but not yet delivered to client
-				k.config.stats.RecordsInMemoryBytes(atomic.LoadInt64(&k.bytesInMemoryCount))
+				k.config.stats.RecordsInMemoryBytes(bytesCount)
 			}
 		}
 	}()

--- a/kinsumer.go
+++ b/kinsumer.go
@@ -5,10 +5,11 @@ package kinsumer
 import (
 	"context"
 	"fmt"
-	"github.com/twitchscience/kinsumer/kinsumeriface"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/twitchscience/kinsumer/kinsumeriface"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
@@ -47,27 +48,25 @@ const (
 
 // MetricUpdate represents a single metric update to be processed
 type MetricUpdate struct {
-	Type        MetricType
-	Value       int64
+	Type         MetricType
+	Value        int64
 	RecordsDelta int64 // For combined updates: change in records count
 	BytesDelta   int64 // For combined updates: change in bytes count
 }
 
 // MetricsManager handles metrics updates through channels to avoid atomic contention
 type MetricsManager struct {
-	updates         chan MetricUpdate
-	stop            chan struct{}
-	recordsCount    int64     // Current records count - only written by metrics goroutine
-	bytesCount      int64     // Current bytes count - only written by metrics goroutine
-	logger          Logger    // Logger for warnings and errors
-	lastDropLogTime time.Time // Last time we logged a drop warning
-	dropCount       int64     // Count of drops since last log
+	updates      chan MetricUpdate
+	stop         chan struct{}
+	recordsCount int64  // Current records count - only written by metrics goroutine
+	bytesCount   int64  // Current bytes count - only written by metrics goroutine
+	logger       Logger // Logger for warnings and errors
 }
 
 // newMetricsManager creates a new MetricsManager with buffered channel
 func newMetricsManager(logger Logger) *MetricsManager {
 	return &MetricsManager{
-		updates: make(chan MetricUpdate, 50000), // Large buffer to handle bursts
+		updates: make(chan MetricUpdate, 5000), // Buffer sized for batched writes
 		stop:    make(chan struct{}),
 		logger:  logger,
 	}
@@ -79,13 +78,8 @@ func (mm *MetricsManager) updateMetric(t MetricType, value int64) {
 	case mm.updates <- MetricUpdate{Type: t, Value: value}:
 		// Successfully queued
 	default:
-		// Channel full - drop metric to avoid blocking hot path
-		mm.dropCount++
-		if time.Since(mm.lastDropLogTime) > time.Minute {
-			mm.logger.Log("Warning: dropped %d metric updates in last minute due to full channel", mm.dropCount)
-			mm.dropCount = 0
-			mm.lastDropLogTime = time.Now()
-		}
+		// Channel full - log immediately since drops should be very rare with batching
+		mm.logger.Log("Warning: metrics channel full, dropping single metric update (type: %d, value: %d)", t, value)
 	}
 }
 
@@ -99,13 +93,8 @@ func (mm *MetricsManager) decrementCombined(recordsDelta, bytesDelta int64) {
 	}:
 		// Successfully queued
 	default:
-		// Channel full - drop metric to avoid blocking hot path
-		mm.dropCount++
-		if time.Since(mm.lastDropLogTime) > time.Minute {
-			mm.logger.Log("Warning: dropped %d metric updates in last minute due to full channel", mm.dropCount)
-			mm.dropCount = 0
-			mm.lastDropLogTime = time.Now()
-		}
+		// Channel full - log immediately since drops should be very rare with batching
+		mm.logger.Log("Warning: metrics channel full, dropping update with %d records, %d bytes", recordsDelta, bytesDelta)
 	}
 }
 

--- a/kinsumer.go
+++ b/kinsumer.go
@@ -52,17 +52,21 @@ type MetricUpdate struct {
 
 // MetricsManager handles metrics updates through channels to avoid atomic contention
 type MetricsManager struct {
-	updates      chan MetricUpdate
-	stop         chan struct{}
-	recordsCount int64 // Current records count - only written by metrics goroutine
-	bytesCount   int64 // Current bytes count - only written by metrics goroutine
+	updates         chan MetricUpdate
+	stop            chan struct{}
+	recordsCount    int64     // Current records count - only written by metrics goroutine
+	bytesCount      int64     // Current bytes count - only written by metrics goroutine
+	logger          Logger    // Logger for warnings and errors
+	lastDropLogTime time.Time // Last time we logged a drop warning
+	dropCount       int64     // Count of drops since last log
 }
 
 // newMetricsManager creates a new MetricsManager with buffered channel
-func newMetricsManager() *MetricsManager {
+func newMetricsManager(logger Logger) *MetricsManager {
 	return &MetricsManager{
 		updates: make(chan MetricUpdate, 50000), // Large buffer to handle bursts
 		stop:    make(chan struct{}),
+		logger:  logger,
 	}
 }
 
@@ -73,6 +77,12 @@ func (mm *MetricsManager) updateMetric(t MetricType, value int64) {
 		// Successfully queued
 	default:
 		// Channel full - drop metric to avoid blocking hot path
+		mm.dropCount++
+		if time.Since(mm.lastDropLogTime) > time.Minute {
+			mm.logger.Log("Warning: dropped %d metric updates in last minute due to full channel", mm.dropCount)
+			mm.dropCount = 0
+			mm.lastDropLogTime = time.Now()
+		}
 	}
 }
 
@@ -215,7 +225,7 @@ func NewWithInterfaces(
 		config:                config,
 		maxAgeForClientRecord: *config.clientRecordMaxAge,
 		maxAgeForLeaderRecord: config.leaderActionFrequency * 5,
-		metricsManager:        newMetricsManager(),
+		metricsManager:        newMetricsManager(config.logger),
 	}
 
 	// Initialize semaphore for limiting concurrent shard record fetching

--- a/kinsumer.go
+++ b/kinsumer.go
@@ -295,25 +295,26 @@ func (k *Kinsumer) refreshShards() (bool, error) {
 	}
 
 	shardIDs, err = loadShardIDsFromDynamo(k.dynamodb, k.metadataTableName)
-
 	if err != nil {
 		return false, err
 	}
 
+	// Here's what we want:
+	// - if shard iterator is TRIM_HORIZON: use the full list of shard IDs, and don't do the bootstrap
+	// - if shard iterator is LATEST: use only open shard IDs, and do the bootstrap
+
 	if len(shardIDs) == 0 {
-		// If we haven't yet registered shards, load them from kinesis
-		var openShardIDs, closedShardIDs []string
-		shardIDs, openShardIDs, closedShardIDs, err = loadShardIDsFromKinesis(k.kinesis, k.streamName)
+
+		// initialiseIteratorType ensures co-ordinated behaviuor across clients for our configured iterator type,
+		// and returns only the shardIDs that this client should care about.
+		shardIDs, err = k.initialiseIteratorType()
 		if err == nil {
-			// If the iterator type is set to LATEST, we need to maek the checkpoints table as such.
-			err = k.createBootstrapMarkers(openShardIDs, closedShardIDs)
-			if err == nil {
-				// Set the cache only if the previous function succeeded
-				err = k.setCachedShardIDs(shardIDs)
-			}
+			// If that didn't error, set the cache
+			err = k.setCachedShardIDs(shardIDs)
 		}
 	}
 
+	// If any above error state was reached, fail
 	if err != nil {
 		return false, err
 	}
@@ -738,23 +739,45 @@ func (k *Kinsumer) NextRecordWithCheckpointer() (rec *ktypes.Record, checkpointe
 	return rec, checkpointer, err
 }
 
+// initialiseIteratorType polls kinesis for shardIDs, and returns the shard IDs that our iterator type should be concerned with.
+// For LATEST, it also initialises entries in the checkpoints table, to ensure that:
+// - Any consumer picking up a shard knows when to start from LATEST
+// - All closed shards are marked as finished, so the leader doesn't re-add them to the shard cache
+func (k *Kinsumer) initialiseIteratorType() ([]string, error) {
+	// Get shard IDs from kinesis
+	allShardIDs, openShardIDs, closedShardIDs, err := loadShardIDsFromKinesis(k.kinesis, k.streamName)
+	if err != nil {
+		return nil, fmt.Errorf("error loading shard IDs from kinesis: %v", err)
+	}
+
+	if k.config.iteratorType != ktypes.ShardIteratorTypeLatest {
+		// If iterator type is not LATEST, return all shard IDs and proceed
+		return allShardIDs, nil
+	}
+
+	// Otherwise, create bootstrap markers and proceed using only open shard IDs
+	err = k.createBootstrapMarkers(openShardIDs, closedShardIDs)
+	if err != nil {
+		return nil, fmt.Errorf("error creating bootstrap markers: %v", err)
+	}
+
+	return openShardIDs, nil
+}
+
 // createBootstrapMarkers creates appropriate markers for shards without existing checkpoints
 // OPEN shards get "LATEST" markers, CLOSED shards get "Finished" markers
 // This distinguishes true bootstrap scenarios from shard scaling operations
 func (k *Kinsumer) createBootstrapMarkers(openShardIDs []string, closedShardIDs []string) error {
-	// Only create bootstrap markers if configured iterator type is LATEST
-	if k.config.iteratorType != ktypes.ShardIteratorTypeLatest {
-		return nil
-	}
 
 	// Load existing checkpoints to see which shards already have records
 	checkpoints, err := loadCheckpoints(k.dynamodb, k.checkpointTableName)
 	if err != nil {
 		return fmt.Errorf("error loading existing checkpoints: %v", err)
 	}
+	// TODO: if this returns soemthing, another client is likely already updating the table. Maybe wait?
 
 	now := time.Now()
-	
+
 	// Create "LATEST" markers for OPEN shards without existing checkpoints
 	for _, shardID := range openShardIDs {
 		// Skip shards that already have checkpoints
@@ -795,12 +818,12 @@ func (k *Kinsumer) createBootstrapMarkers(openShardIDs []string, closedShardIDs 
 
 		// Create finished marker for closed shard
 		record := checkpointRecord{
-			Shard:         shardID,
+			Shard:          shardID,
 			SequenceNumber: nil, // No sequence number for finished shards
-			LastUpdate:    now.UnixNano(),
-			LastUpdateRFC: now.UTC().Format(time.RFC1123Z),
-			Finished:      aws.Int64(now.UnixNano()), // Mark as finished
-			FinishedRFC:   aws.String(now.UTC().Format(time.RFC1123Z)),
+			LastUpdate:     now.UnixNano(),
+			LastUpdateRFC:  now.UTC().Format(time.RFC1123Z),
+			Finished:       aws.Int64(now.UnixNano()), // Mark as finished
+			FinishedRFC:    aws.String(now.UTC().Format(time.RFC1123Z)),
 			// Leave OwnerID and OwnerName as nil for bootstrap markers
 		}
 

--- a/kinsumer.go
+++ b/kinsumer.go
@@ -42,12 +42,15 @@ const (
 	RecordsDecrement
 	BytesIncrement
 	BytesDecrement
+	CombinedDecrement
 )
 
 // MetricUpdate represents a single metric update to be processed
 type MetricUpdate struct {
-	Type  MetricType
-	Value int64
+	Type        MetricType
+	Value       int64
+	RecordsDelta int64 // For combined updates: change in records count
+	BytesDelta   int64 // For combined updates: change in bytes count
 }
 
 // MetricsManager handles metrics updates through channels to avoid atomic contention
@@ -86,6 +89,26 @@ func (mm *MetricsManager) updateMetric(t MetricType, value int64) {
 	}
 }
 
+// decrementCombined sends a combined decrement update for both records and bytes
+func (mm *MetricsManager) decrementCombined(recordsDelta, bytesDelta int64) {
+	select {
+	case mm.updates <- MetricUpdate{
+		Type:         CombinedDecrement,
+		RecordsDelta: recordsDelta,
+		BytesDelta:   bytesDelta,
+	}:
+		// Successfully queued
+	default:
+		// Channel full - drop metric to avoid blocking hot path
+		mm.dropCount++
+		if time.Since(mm.lastDropLogTime) > time.Minute {
+			mm.logger.Log("Warning: dropped %d metric updates in last minute due to full channel", mm.dropCount)
+			mm.dropCount = 0
+			mm.lastDropLogTime = time.Now()
+		}
+	}
+}
+
 // getCurrentMetrics returns current metric values using atomic loads
 func (mm *MetricsManager) getCurrentMetrics() (int64, int64) {
 	return atomic.LoadInt64(&mm.recordsCount), atomic.LoadInt64(&mm.bytesCount)
@@ -107,6 +130,9 @@ func (mm *MetricsManager) run() {
 				bytesCount += update.Value
 			case BytesDecrement:
 				bytesCount -= update.Value
+			case CombinedDecrement:
+				recordsCount -= update.RecordsDelta
+				bytesCount -= update.BytesDelta
 			}
 
 			// Update shared state - single writer, no contention
@@ -558,8 +584,7 @@ func (k *Kinsumer) Run() error {
 				if !k.config.manualCheckpointing {
 					record.checkpointer.update(aws.ToString(record.record.SequenceNumber))
 				}
-				k.metricsManager.updateMetric(RecordsDecrement, 1)
-				k.metricsManager.updateMetric(BytesDecrement, record.payloadBytes)
+				k.metricsManager.decrementCombined(1, record.payloadBytes)
 				record = nil
 			case se := <-k.shardErrors:
 				k.errors <- fmt.Errorf("shard error (%s) in %s: %s", se.shardID, se.action, se.err)

--- a/kinsumer.go
+++ b/kinsumer.go
@@ -493,7 +493,7 @@ func (k *Kinsumer) Run() error {
 				}
 			case <-bufferReportTicker.C:
 				// Report the current number of records pulled from Kinesis but not yet delivered to client
-				k.config.stats.RecordsInMemory(int(atomic.LoadInt64(&k.recordsInMemoryCount)))
+				k.config.stats.RecordsInMemory(atomic.LoadInt64(&k.recordsInMemoryCount))
 				// Report the current total bytes of record payloads pulled from Kinesis but not yet delivered to client
 				k.config.stats.RecordsInMemoryBytes(atomic.LoadInt64(&k.bytesInMemoryCount))
 			}

--- a/kinsumer.go
+++ b/kinsumer.go
@@ -4,7 +4,9 @@ package kinsumer
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"math/rand"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -755,68 +757,83 @@ func (k *Kinsumer) initialiseIteratorType() ([]string, error) {
 		return allShardIDs, nil
 	}
 
-	// Otherwise, create bootstrap markers and proceed using only open shard IDs
-	err = k.createBootstrapMarkers(openShardIDs, closedShardIDs)
+	// Otherwise, create bootstrap checkpoints and proceed using only open shard IDs
+	err = k.createBootstrapCheckpoints(openShardIDs, closedShardIDs)
 	if err != nil {
-		return nil, fmt.Errorf("error creating bootstrap markers: %v", err)
+		return nil, fmt.Errorf("error creating bootstrap checkpoints: %v", err)
 	}
 
 	return openShardIDs, nil
 }
 
-// createBootstrapMarkers creates appropriate markers for shards without existing checkpoints
-// OPEN shards get "LATEST" markers, CLOSED shards get "Finished" markers
+// createBootstrapCheckpoints creates appropriate checkpoint records for shards without existing checkpoints
+// OPEN shards get "LATEST" sequence number checkpoints, CLOSED shards get "Finished" checkpoints
 // This distinguishes true bootstrap scenarios from shard scaling operations
-func (k *Kinsumer) createBootstrapMarkers(openShardIDs []string, closedShardIDs []string) error {
+func (k *Kinsumer) createBootstrapCheckpoints(openShardIDs []string, closedShardIDs []string) error {
 
-	// Load existing checkpoints to see which shards already have records
-	checkpoints, err := loadCheckpoints(k.dynamodb, k.checkpointTableName)
-	if err != nil {
-		return fmt.Errorf("error loading existing checkpoints: %v", err)
+	nCheckpoints := 0
+	var checkpoints map[string]*checkpointRecord
+	var err error
+
+	for {
+		// It is safe for more than one client to bootstrap at a time, but we don't want to spam when we have a lot of shards.
+		// So, we loop here to check if a bootstrap is in progress.
+		// If it is, we wait until either it's done, or it stopped updating before it finshed.
+		// If the latter, we break the loop and take over writing the remaining shard bootstraps.
+
+		// Load existing checkpoints to see which shards already have records
+		checkpoints, err = loadCheckpoints(k.dynamodb, k.checkpointTableName)
+		if err != nil {
+			return fmt.Errorf("error loading existing checkpoints: %v", err)
+		}
+
+		if len(checkpoints) >= len(openShardIDs)+len(closedShardIDs) {
+			// Another client has completed the bootstrap
+			// >= just in case it's during a shard action
+			return nil
+		}
+		if len(checkpoints) != nCheckpoints {
+			// Another client is updating the table, give it a chance to finish, and check again
+			nCheckpoints = len(checkpoints)
+			jitter := time.Duration(900+rand.Intn(200)) * time.Millisecond
+			time.Sleep(jitter)
+			continue
+		}
+		// Otherwise, we have shard IDs to bootstrap,  so proceed
+		break
 	}
-	// TODO: if this returns soemthing, another client is likely already updating the table. Maybe wait?
 
 	now := time.Now()
 
-	// Create "LATEST" markers for OPEN shards without existing checkpoints
+	// Create "LATEST" checkpoints for OPEN shards without existing checkpoints
 	for _, shardID := range openShardIDs {
 		// Skip shards that already have checkpoints
 		if _, exists := checkpoints[shardID]; exists {
 			continue
 		}
 
-		// Create bootstrap marker with "LATEST" as sequence number
+		// Create bootstrap checkpoint with "LATEST" as sequence number
 		record := checkpointRecord{
 			Shard:          shardID,
-			SequenceNumber: aws.String("LATEST"), // Bootstrap marker
+			SequenceNumber: aws.String("LATEST"), // Bootstrap checkpoint
 			LastUpdate:     now.UnixNano(),
 			LastUpdateRFC:  now.UTC().Format(time.RFC1123Z),
-			// Leave OwnerID and OwnerName as nil for bootstrap markers
+			// Leave OwnerID and OwnerName as nil for bootstrap checkpoints
 		}
 
-		item, err := attributevalue.MarshalMap(record)
-		if err != nil {
-			return fmt.Errorf("error marshalling LATEST bootstrap marker for shard %s: %v", shardID, err)
-		}
-
-		// Use unconditional PutItem to avoid race condition issues
-		_, err = k.dynamodb.PutItem(context.Background(), &dynamodb.PutItemInput{
-			TableName: aws.String(k.checkpointTableName),
-			Item:      item,
-		})
-		if err != nil {
-			return fmt.Errorf("error writing LATEST bootstrap marker for shard %s: %v", shardID, err)
+		if err := k.writeCheckpointWithCondition(record); err != nil {
+			return fmt.Errorf("error bootstrapping checkpoint for open shard %s: %v", shardID, err)
 		}
 	}
 
-	// Create "Finished" markers for CLOSED shards without existing checkpoints
+	// Create "Finished" checkpoints for CLOSED shards without existing checkpoints
 	for _, shardID := range closedShardIDs {
 		// Skip shards that already have checkpoints
 		if _, exists := checkpoints[shardID]; exists {
 			continue
 		}
 
-		// Create finished marker for closed shard
+		// Create finished checkpoint for closed shard
 		record := checkpointRecord{
 			Shard:          shardID,
 			SequenceNumber: nil, // No sequence number for finished shards
@@ -824,26 +841,79 @@ func (k *Kinsumer) createBootstrapMarkers(openShardIDs []string, closedShardIDs 
 			LastUpdateRFC:  now.UTC().Format(time.RFC1123Z),
 			Finished:       aws.Int64(now.UnixNano()), // Mark as finished
 			FinishedRFC:    aws.String(now.UTC().Format(time.RFC1123Z)),
-			// Leave OwnerID and OwnerName as nil for bootstrap markers
+			// Leave OwnerID and OwnerName as nil for bootstrap checkpoints
 		}
 
-		item, err := attributevalue.MarshalMap(record)
-		if err != nil {
-			return fmt.Errorf("error marshalling Finished bootstrap marker for shard %s: %v", shardID, err)
-		}
-
-		// Use unconditional PutItem to avoid race condition issues
-		_, err = k.dynamodb.PutItem(context.Background(), &dynamodb.PutItemInput{
-			TableName: aws.String(k.checkpointTableName),
-			Item:      item,
-		})
-		if err != nil {
-			return fmt.Errorf("error writing Finished bootstrap marker for shard %s: %v", shardID, err)
+		if err := k.writeCheckpointWithCondition(record); err != nil {
+			return fmt.Errorf("error bootstrapping checkpoint for closed shard: %s: %v", shardID, err)
 		}
 	}
 
 	return nil
 }
+
+// writeCheckpointWithCondition writes a single checkpoint record with conditional expression to prevent overwrites
+// Returns nil if the record was written successfully or if it already exists (no-op)
+// Handles throttling with exponential backoff and retry
+func (k *Kinsumer) writeCheckpointWithCondition(record checkpointRecord) error {
+	// Marshal the checkpoint record to DynamoDB item
+	item, err := attributevalue.MarshalMap(record)
+	if err != nil {
+		return fmt.Errorf("error marshalling checkpoint record: %v", err)
+	}
+
+	const maxRetries = 3
+	var lastErr error
+
+	// Retry with exponential backoff for throttling
+	for retry := 0; retry < maxRetries; retry++ {
+		// Use conditional PutItem to prevent overwriting existing checkpoints
+		_, err = k.dynamodb.PutItem(context.Background(), &dynamodb.PutItemInput{
+			TableName:                    aws.String(k.checkpointTableName),
+			Item:                         item,
+			ConditionExpression:          aws.String("attribute_not_exists(#shard)"),
+			ExpressionAttributeNames:     map[string]string{"#shard": "Shard"},
+		})
+
+		if err != nil {
+			lastErr = err
+
+			// Check if it's a conditional check failure (record already exists)
+			var conditionalCheckFailed *dbtypes.ConditionalCheckFailedException
+			if errors.As(err, &conditionalCheckFailed) {
+				// This is expected when another client has already written the checkpoint
+				// Return nil to indicate this is not an error condition
+				return nil
+			}
+
+			// Check if it's a throttling exception
+			var provisionedThroughputErr *dbtypes.ProvisionedThroughputExceededException
+			if errors.As(err, &provisionedThroughputErr) {
+				// Retry on throttling with exponential backoff
+				k.config.logger.Log("DynamoDB throttling on checkpoint write (retry %d/%d): %v", retry+1, maxRetries, err)
+
+				if retry < maxRetries-1 { // Don't sleep after the last attempt
+					// Exponential backoff with jitter: base delay * 2^retry + random jitter
+					baseDelay := 100 * time.Millisecond
+					backoffDelay := time.Duration(1<<uint(retry)) * baseDelay
+					jitter := time.Duration(rand.Intn(100)) * time.Millisecond
+					time.Sleep(backoffDelay + jitter)
+				}
+				continue
+			}
+
+			// For other errors, return immediately (no retry)
+			return err
+		}
+
+		// Success
+		return nil
+	}
+
+	// All retries exhausted, return the last error received
+	return lastErr
+}
+
 
 // CreateRequiredTables will create the required dynamodb tables
 // based on the applicationName

--- a/kinsumer.go
+++ b/kinsumer.go
@@ -302,10 +302,11 @@ func (k *Kinsumer) refreshShards() (bool, error) {
 
 	if len(shardIDs) == 0 {
 		// If we haven't yet registered shards, load them from kinesis
-		shardIDs, err = loadShardIDsFromKinesis(k.kinesis, k.streamName)
+		var openShardIDs, closedShardIDs []string
+		shardIDs, openShardIDs, closedShardIDs, err = loadShardIDsFromKinesis(k.kinesis, k.streamName)
 		if err == nil {
 			// If the iterator type is set to LATEST, we need to maek the checkpoints table as such.
-			err = k.createBootstrapMarkers(shardIDs)
+			err = k.createBootstrapMarkers(openShardIDs, closedShardIDs)
 			if err == nil {
 				// Set the cache only if the previous function succeeded
 				err = k.setCachedShardIDs(shardIDs)
@@ -737,9 +738,10 @@ func (k *Kinsumer) NextRecordWithCheckpointer() (rec *ktypes.Record, checkpointe
 	return rec, checkpointer, err
 }
 
-// createBootstrapMarkers creates "LATEST" markers for shards without existing checkpoints
+// createBootstrapMarkers creates appropriate markers for shards without existing checkpoints
+// OPEN shards get "LATEST" markers, CLOSED shards get "Finished" markers
 // This distinguishes true bootstrap scenarios from shard scaling operations
-func (k *Kinsumer) createBootstrapMarkers(shardIDs []string) error {
+func (k *Kinsumer) createBootstrapMarkers(openShardIDs []string, closedShardIDs []string) error {
 	// Only create bootstrap markers if configured iterator type is LATEST
 	if k.config.iteratorType != ktypes.ShardIteratorTypeLatest {
 		return nil
@@ -752,8 +754,9 @@ func (k *Kinsumer) createBootstrapMarkers(shardIDs []string) error {
 	}
 
 	now := time.Now()
-	// Create bootstrap markers for shards without existing checkpoints
-	for _, shardID := range shardIDs {
+	
+	// Create "LATEST" markers for OPEN shards without existing checkpoints
+	for _, shardID := range openShardIDs {
 		// Skip shards that already have checkpoints
 		if _, exists := checkpoints[shardID]; exists {
 			continue
@@ -770,7 +773,7 @@ func (k *Kinsumer) createBootstrapMarkers(shardIDs []string) error {
 
 		item, err := attributevalue.MarshalMap(record)
 		if err != nil {
-			return fmt.Errorf("error marshalling bootstrap marker for shard %s: %v", shardID, err)
+			return fmt.Errorf("error marshalling LATEST bootstrap marker for shard %s: %v", shardID, err)
 		}
 
 		// Use unconditional PutItem to avoid race condition issues
@@ -779,7 +782,40 @@ func (k *Kinsumer) createBootstrapMarkers(shardIDs []string) error {
 			Item:      item,
 		})
 		if err != nil {
-			return fmt.Errorf("error writing bootstrap marker for shard %s: %v", shardID, err)
+			return fmt.Errorf("error writing LATEST bootstrap marker for shard %s: %v", shardID, err)
+		}
+	}
+
+	// Create "Finished" markers for CLOSED shards without existing checkpoints
+	for _, shardID := range closedShardIDs {
+		// Skip shards that already have checkpoints
+		if _, exists := checkpoints[shardID]; exists {
+			continue
+		}
+
+		// Create finished marker for closed shard
+		record := checkpointRecord{
+			Shard:         shardID,
+			SequenceNumber: nil, // No sequence number for finished shards
+			LastUpdate:    now.UnixNano(),
+			LastUpdateRFC: now.UTC().Format(time.RFC1123Z),
+			Finished:      aws.Int64(now.UnixNano()), // Mark as finished
+			FinishedRFC:   aws.String(now.UTC().Format(time.RFC1123Z)),
+			// Leave OwnerID and OwnerName as nil for bootstrap markers
+		}
+
+		item, err := attributevalue.MarshalMap(record)
+		if err != nil {
+			return fmt.Errorf("error marshalling Finished bootstrap marker for shard %s: %v", shardID, err)
+		}
+
+		// Use unconditional PutItem to avoid race condition issues
+		_, err = k.dynamodb.PutItem(context.Background(), &dynamodb.PutItemInput{
+			TableName: aws.String(k.checkpointTableName),
+			Item:      item,
+		})
+		if err != nil {
+			return fmt.Errorf("error writing Finished bootstrap marker for shard %s: %v", shardID, err)
 		}
 	}
 

--- a/kinsumer.go
+++ b/kinsumer.go
@@ -65,6 +65,7 @@ type Kinsumer struct {
 	maxAgeForClientRecord time.Duration           // Cutoff for client/checkpoint records we read from dynamodb before we assume the record is stale
 	maxAgeForLeaderRecord time.Duration           // Cutoff for leader/shard cache records we read from dynamodb before we assume the record is stale
 	shardSemaphore        chan struct{}           // Semaphore to limit concurrent shard record fetching
+	recordsInMemoryCount  int64                   // Atomic counter for records pulled from Kinesis but not yet delivered to client
 }
 
 // New returns a Kinsumer Interface with default kinesis and dynamodb instances, to be used in ec2 instances to get default auth and config
@@ -460,6 +461,7 @@ func (k *Kinsumer) Run() error {
 				if !k.config.manualCheckpointing {
 					record.checkpointer.update(aws.ToString(record.record.SequenceNumber))
 				}
+				atomic.AddInt64(&k.recordsInMemoryCount, -1)
 				record = nil
 			case se := <-k.shardErrors:
 				k.errors <- fmt.Errorf("shard error (%s) in %s: %s", se.shardID, se.action, se.err)
@@ -487,8 +489,8 @@ func (k *Kinsumer) Run() error {
 					k.isRestartingConsumers = false
 				}
 			case <-bufferReportTicker.C:
-				// Report the current number of records buffered in memory
-				k.config.stats.RecordsInMemory(len(k.records))
+				// Report the current number of records pulled from Kinesis but not yet delivered to client
+				k.config.stats.RecordsInMemory(int(atomic.LoadInt64(&k.recordsInMemoryCount)))
 			}
 		}
 	}()

--- a/kinsumer_bootstrap_test.go
+++ b/kinsumer_bootstrap_test.go
@@ -1,0 +1,116 @@
+package kinsumer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/kinesis"
+	ktypes "github.com/aws/aws-sdk-go-v2/service/kinesis/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreateBootstrapCheckpoints tests the createBootstrapCheckpoints function
+// with a simple happy path scenario using real DynamoDB operations
+func TestCreateBootstrapCheckpoints(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	streamName := "TestCreateBootstrapCheckpoints_stream"
+
+	k, d := kinesisAndDynamoInstances(t)
+
+	defer func() {
+		err := cleanupTestEnvironment(t, k, d, streamName)
+		require.NoError(t, err, "Problems cleaning up the test environment")
+	}()
+
+	// Setup stream and DynamoDB tables
+	err := setupTestEnvironment(t, k, d, streamName, 2)
+	require.NoError(t, err, "Problems setting up the test environment")
+
+	// Create kinsumer instance to access the createBootstrapCheckpoints method
+	config := NewConfig().WithIteratorType(ktypes.ShardIteratorTypeLatest)
+	kinsumer, err := NewWithInterfaces(k, d, streamName, *applicationName, "test_client", "", config)
+	require.NoError(t, err, "Error creating kinsumer instance")
+
+	// Perform merge to create CLOSED shards
+	desc, err := k.DescribeStream(t.Context(), &kinesis.DescribeStreamInput{
+		StreamName: &streamName,
+		Limit:      aws.Int32(shardLimit),
+	})
+	require.NoError(t, err, "Error describing stream")
+	initialShards := desc.StreamDescription.Shards
+	require.True(t, len(initialShards) >= 2, "Need at least 2 shards for merge")
+
+	_, err = k.MergeShards(t.Context(), &kinesis.MergeShardsInput{
+		StreamName:           &streamName,
+		ShardToMerge:         aws.String(*initialShards[0].ShardId),
+		AdjacentShardToMerge: aws.String(*initialShards[1].ShardId),
+	})
+	require.NoError(t, err, "Problem merging shards")
+
+	// Wait for merge to complete
+	timeout := time.After(30 * time.Second)
+	for {
+		desc, err = k.DescribeStream(t.Context(), &kinesis.DescribeStreamInput{
+			StreamName: &streamName,
+			Limit:      aws.Int32(shardLimit),
+		})
+		require.NoError(t, err, "Error describing stream during merge wait")
+		if desc.StreamDescription.StreamStatus == "ACTIVE" {
+			break
+		}
+		select {
+		case <-timeout:
+			require.FailNow(t, "Timeout waiting for merge to complete")
+		default:
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+
+	// Get the current shards after merge (should have OPEN and CLOSED shards)
+	allShardIDs, openShardIDs, closedShardIDs, err := loadShardIDsFromKinesis(k, streamName)
+	require.NoError(t, err, "Error loading shard IDs from Kinesis")
+	require.Greater(t, len(allShardIDs), 0, "Should have at least one shard")
+	require.Greater(t, len(closedShardIDs), 0, "Should have at least one CLOSED shard after merge")
+	require.Greater(t, len(openShardIDs), 0, "Should have at least one OPEN shard after merge")
+
+	t.Logf("Found %d total shards: %d OPEN, %d CLOSED", len(allShardIDs), len(openShardIDs), len(closedShardIDs))
+
+	// Test the createBootstrapCheckpoints function
+	err = kinsumer.createBootstrapCheckpoints(openShardIDs, closedShardIDs)
+	require.NoError(t, err, "createBootstrapCheckpoints failed")
+
+	// Verify the checkpoint records were created correctly
+	checkpoints, err := loadCheckpoints(d, kinsumer.checkpointTableName)
+	require.NoError(t, err, "Error loading checkpoints from DynamoDB")
+
+	// Verify all shards have checkpoint records
+	assert.Equal(t, len(allShardIDs), len(checkpoints), "Should have checkpoint record for every shard")
+
+	// Verify OPEN shards have "LATEST" sequence numbers and no Finished timestamp
+	for _, shardID := range openShardIDs {
+		checkpoint, exists := checkpoints[shardID]
+		require.True(t, exists, "OPEN shard %s should have checkpoint record", shardID)
+		require.NotNil(t, checkpoint.SequenceNumber, "OPEN shard %s should have sequence number", shardID)
+		assert.Equal(t, "LATEST", *checkpoint.SequenceNumber, "OPEN shard %s should have LATEST sequence number", shardID)
+		assert.Nil(t, checkpoint.Finished, "OPEN shard %s should not be marked as finished", shardID)
+	}
+
+	// Verify CLOSED shards have no sequence number and are marked as finished
+	for _, shardID := range closedShardIDs {
+		checkpoint, exists := checkpoints[shardID]
+		require.True(t, exists, "CLOSED shard %s should have checkpoint record", shardID)
+		assert.Nil(t, checkpoint.SequenceNumber, "CLOSED shard %s should have nil sequence number", shardID)
+		assert.NotNil(t, checkpoint.Finished, "CLOSED shard %s should be marked as finished", shardID)
+	}
+
+	t.Logf("✓ Successfully verified %d OPEN shards with LATEST checkpoints", len(openShardIDs))
+	t.Logf("✓ Successfully verified %d CLOSED shards with Finished checkpoints", len(closedShardIDs))
+}
+
+
+

--- a/kinsumer_test.go
+++ b/kinsumer_test.go
@@ -712,6 +712,203 @@ func runSplitTest(t *testing.T, iteratorType ktypes.ShardIteratorType) {
 	waitGroup.Wait()
 }
 
+// TestClosedShardsOnInitialization tests client initialization when CLOSED shards already exist
+// This specifically tests bootstrap behavior when ListShards returns existing CLOSED shards
+func TestClosedShardsOnInitialization(t *testing.T) {
+	testCases := []struct {
+		name           string
+		iteratorType   ktypes.ShardIteratorType
+		expectDataLoss bool
+	}{
+		{"TRIM_HORIZON", ktypes.ShardIteratorTypeTrimHorizon, false},
+		{"LATEST", ktypes.ShardIteratorTypeLatest, false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			runClosedShardsOnInitializationTest(t, tc.iteratorType, tc.expectDataLoss)
+		})
+	}
+}
+
+func runClosedShardsOnInitializationTest(t *testing.T, iteratorType ktypes.ShardIteratorType, expectDataLoss bool) {
+	const (
+		numberOfEventsToTest = 4321
+		numberOfClients      = 3
+	)
+	streamName := "TestClosedShardsInit_stream" + string(iteratorType)
+
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	k, d := kinesisAndDynamoInstances(t)
+
+	defer func() {
+		err := cleanupTestEnvironment(t, k, d, streamName)
+		require.NoError(t, err, "Problems cleaning up the test environment")
+	}()
+
+	err := setupTestEnvironment(t, k, d, streamName, shardCount)
+	require.NoError(t, err, "Problems setting up the test environment")
+
+	// Send initial data to the stream BEFORE merge operation
+	err = spamStream(t, k, numberOfEventsToTest, streamName)
+	require.NoError(t, err, "Problems sending initial data")
+
+	// Perform merge operation to create CLOSED shards (copied from TestSplit)
+	desc, err := k.DescribeStream(t.Context(), &kinesis.DescribeStreamInput{
+		StreamName: &streamName,
+		Limit:      aws.Int32(shardLimit),
+	})
+	require.NoError(t, err, "Error describing stream")
+	shards := desc.StreamDescription.Shards
+	require.True(t, len(shards) >= 2, "Fewer than 2 shards")
+
+	_, err = k.MergeShards(t.Context(), &kinesis.MergeShardsInput{
+		StreamName:           &streamName,
+		ShardToMerge:         aws.String(*shards[0].ShardId),
+		AdjacentShardToMerge: aws.String(*shards[1].ShardId),
+	})
+	require.NoError(t, err, "Problem merging shards")
+
+	// Wait for merge to complete
+	require.True(t, shardCount <= shardLimit, "Too many shards")
+	timeout := time.After(time.Second)
+	for {
+		desc, err = k.DescribeStream(t.Context(), &kinesis.DescribeStreamInput{
+			StreamName: &streamName,
+			Limit:      aws.Int32(shardLimit),
+		})
+		require.NoError(t, err, "Error describing stream")
+		if desc.StreamDescription.StreamStatus == "ACTIVE" {
+			break
+		}
+		select {
+		case <-timeout:
+			require.FailNow(t, "Timedout after merging shards")
+		default:
+			time.Sleep(*resourceChangeTimeout)
+		}
+	}
+	newShards := desc.StreamDescription.Shards
+	require.Equal(t, shardCount+1, int32(len(newShards)), "Wrong number of shards after merging")
+
+	// Verify we have CLOSED shards (merged shards should be closed)
+	closedShards := 0
+	openShards := 0
+	for _, shard := range newShards {
+		if shard.SequenceNumberRange.EndingSequenceNumber != nil {
+			closedShards++
+		} else {
+			openShards++
+		}
+	}
+	require.Greater(t, closedShards, 0, "Should have at least one CLOSED shard after merge")
+	require.Greater(t, openShards, 0, "Should have at least one OPEN shard after merge")
+
+	t.Logf("After merge: %d OPEN shards, %d CLOSED shards", openShards, closedShards)
+
+	// Sleep for a bit before adding clients
+	time.Sleep(1000 * time.Millisecond)
+
+	// NOW initialize clients AFTER shards are split and CLOSED shards exist
+	clients := make([]*Kinsumer, numberOfClients)
+	output := make(chan int, numberOfEventsToTest)
+	var waitGroup sync.WaitGroup
+
+	config := NewConfig().WithBufferSize(numberOfEventsToTest * 2).
+		WithShardCheckFrequency(500 * time.Millisecond).
+		WithLeaderActionFrequency(500 * time.Millisecond).
+		WithCommitFrequency(50 * time.Millisecond).
+		WithIteratorType(iteratorType)
+
+	// Initialize clients
+	for i := 0; i < numberOfClients; i++ {
+		if i > 0 {
+			time.Sleep(50 * time.Millisecond) // Add clients slowly
+		}
+
+		clients[i], err = NewWithInterfaces(k, d, streamName, *applicationName, fmt.Sprintf("test_closed_%d", i), "", config)
+		require.NoError(t, err, "NewWithInterfaces() failed")
+		clients[i].clientID = fmt.Sprintf("closed_test_%d", i+1)
+
+		err = clients[i].Run()
+		require.NoError(t, err, "kinsumer.Run() failed")
+
+		waitGroup.Add(1)
+		go func(client *Kinsumer, ci int) {
+			defer waitGroup.Done()
+			for {
+				data, innerError := client.Next()
+				require.NoError(t, innerError, "kinsumer.Next() failed")
+				if data == nil {
+					return
+				}
+				idx, _ := strconv.Atoi(string(data))
+				output <- idx
+			}
+		}(clients[i], i)
+		defer func(ci int) {
+			if clients[ci] != nil {
+				clients[ci].Stop()
+			}
+		}(i)
+	}
+
+	// Give clients time to initialize and start consuming
+	time.Sleep(2 * time.Second)
+
+	// // DEBUG: Print checkpoints table contents after client initialization
+	// checkpoints, err := loadCheckpoints(d, clients[0].checkpointTableName)
+	// require.NoError(t, err, "Error loading checkpoints for debugging")
+	// t.Logf("=== CHECKPOINTS AFTER CLIENT INITIALIZATION ===")
+	// for shardID, checkpoint := range checkpoints {
+	// 	seqNum := "nil"
+	// 	if checkpoint.SequenceNumber != nil {
+	// 		seqNum = *checkpoint.SequenceNumber
+	// 	}
+	// 	finished := "nil"
+	// 	if checkpoint.Finished != nil {
+	// 		finished = fmt.Sprintf("%d", *checkpoint.Finished)
+	// 	}
+	// 	ownerID := "nil"
+	// 	if checkpoint.OwnerID != nil {
+	// 		ownerID = *checkpoint.OwnerID
+	// 	}
+	// 	t.Logf("Shard %s: SequenceNumber=%s, Finished=%s, OwnerID=%s",
+	// 		shardID, seqNum, finished, ownerID)
+	// }
+	// t.Logf("=== END CHECKPOINTS DEBUG ===")
+
+	// Read any data that was consumed during initialization
+	foundDuringInit := readEvents(t, output, numberOfEventsToTest)
+
+	// Verify behavior based on iterator type
+	if iteratorType == ktypes.ShardIteratorTypeLatest {
+		assert.Equal(t, 0, foundDuringInit, "Should read no historical data with LATEST")
+	} else {
+		assert.Equal(t, numberOfEventsToTest, foundDuringInit, "Should read all historical data with TRIM_HORIZON")
+	}
+
+	// Send new data after clients are initialized
+	err = spamStream(t, k, numberOfEventsToTest, streamName)
+	require.NoError(t, err, "Problems sending new data")
+
+	// Read new data - should always work regardless of iterator type
+	foundAfterInit := readEvents(t, output, numberOfEventsToTest)
+	assert.Equal(t, numberOfEventsToTest, foundAfterInit, "Should read all new data regardless of iterator type")
+
+	// Cleanup
+	for ci, client := range clients {
+		client.Stop()
+		clients[ci] = nil
+	}
+
+	drain(t, output)
+	waitGroup.Wait()
+}
+
 func drain(t *testing.T, output chan int) {
 	extraEvents := 0
 	// Drain in case events duplicated, so we don't hang.

--- a/kinsumer_test.go
+++ b/kinsumer_test.go
@@ -555,11 +555,11 @@ func runSplitTest(t *testing.T, iteratorType ktypes.ShardIteratorType) {
 	output := make(chan int, numberOfClients)
 	var waitGroup sync.WaitGroup
 
-	config := NewConfig().WithBufferSize(numberOfEventsToTest)
-	config = config.WithShardCheckFrequency(500 * time.Millisecond)
-	config = config.WithLeaderActionFrequency(500 * time.Millisecond)
-	config = config.WithCommitFrequency(50 * time.Millisecond)
-	config = config.WithIteratorType(iteratorType)
+	config := NewConfig().WithBufferSize(numberOfEventsToTest).
+		WithShardCheckFrequency(500 * time.Millisecond).
+		WithLeaderActionFrequency(500 * time.Millisecond).
+		WithCommitFrequency(50 * time.Millisecond).
+		WithIteratorType(iteratorType)
 
 	for i := 0; i < numberOfClients; i++ {
 		if i > 0 {

--- a/kinsumer_test.go
+++ b/kinsumer_test.go
@@ -514,11 +514,27 @@ func TestLeader(t *testing.T) {
 
 // TestSplit is an integration test of merging shards, checking the closed and new shards are handled correctly.
 func TestSplit(t *testing.T) {
+	testCases := []struct {
+		name         string
+		iteratorType ktypes.ShardIteratorType
+	}{
+		{"TRIM_HORIZON", ktypes.ShardIteratorTypeTrimHorizon},
+		{"LATEST", ktypes.ShardIteratorTypeLatest},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			runSplitTest(t, tc.iteratorType)
+		})
+	}
+}
+
+func runSplitTest(t *testing.T, iteratorType ktypes.ShardIteratorType) {
 	const (
 		numberOfEventsToTest = 4321
 		numberOfClients      = 3
 	)
-	streamName := "TestSplit_stream"
+	streamName := "TestSplit_stream" + string(iteratorType)
 
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
@@ -543,6 +559,7 @@ func TestSplit(t *testing.T) {
 	config = config.WithShardCheckFrequency(500 * time.Millisecond)
 	config = config.WithLeaderActionFrequency(500 * time.Millisecond)
 	config = config.WithCommitFrequency(50 * time.Millisecond)
+	config = config.WithIteratorType(iteratorType)
 
 	for i := 0; i < numberOfClients; i++ {
 		if i > 0 {
@@ -579,7 +596,33 @@ func TestSplit(t *testing.T) {
 	err = spamStream(t, k, numberOfEventsToTest, streamName)
 	require.NoError(t, err, "Problems spamming stream with events")
 
-	readEvents(t, output, numberOfEventsToTest)
+	foundBefore := readEvents(t, output, numberOfEventsToTest)
+	// Should have some data
+	assert.Greater(t, foundBefore, 0)
+
+	// If using LATEST, we expect to have started at some point after the data came in,
+	// For TRIM_HORIZON, data should be complete.
+	if iteratorType == ktypes.ShardIteratorTypeLatest {
+		assert.Less(t, foundBefore, numberOfEventsToTest)
+	} else if iteratorType == ktypes.ShardIteratorTypeTrimHorizon {
+		assert.Equal(t, foundBefore, numberOfEventsToTest)
+	}
+
+	// TODO: Test may have failed before due to timing issue.
+	// Check this iteration of the test on the previous implementation, to see if it does reproduce the problem.
+	// Timing issue not present in TestShardsMerged, so we do have validation of our implementation.
+
+	// Wait a bit for all shard consumption to begin
+	time.Sleep(1000 * time.Millisecond)
+
+	// Now we should get all the data we send from here in
+	err = spamStream(t, k, numberOfEventsToTest, streamName)
+	require.NoError(t, err, "Problems spamming stream with events")
+
+	foundBefore2 := readEvents(t, output, numberOfEventsToTest)
+	// Should have some data
+	assert.Greater(t, foundBefore2, 0)
+	assert.Equal(t, foundBefore2, numberOfEventsToTest)
 
 	desc, err := k.DescribeStream(t.Context(), &kinesis.DescribeStreamInput{
 		StreamName: &streamName,
@@ -632,11 +675,15 @@ func TestSplit(t *testing.T) {
 	newShards := desc.StreamDescription.Shards
 	require.Equal(t, shardCount+1, int32(len(newShards)), "Wrong number of shards after merging")
 
+	// Check if we got all the events we sent during the shard action
+	foundDuring := readEvents(t, output, shardActionEvents)
+	assert.Equal(t, shardActionEvents, foundDuring)
+
 	err = spamStream(t, k, numberOfEventsToTest, streamName)
 	require.NoError(t, err, "Problems spamming stream with events")
 
-	expectedEventsAfterMerge := shardActionEvents + numberOfEventsToTest
-	readEvents(t, output, expectedEventsAfterMerge)
+	foundAfter := readEvents(t, output, numberOfEventsToTest)
+	assert.Equal(t, numberOfEventsToTest, foundAfter)
 
 	// Sleep here to wait for stuff to calm down. When running this test
 	// by itself it passes without the sleep but when running all the tests
@@ -680,7 +727,7 @@ DrainLoop:
 	assert.Equal(t, 0, extraEvents, "Got %d extra events afterwards", extraEvents)
 }
 
-func readEvents(t *testing.T, output chan int, numberOfEventsToTest int) {
+func readEvents(t *testing.T, output chan int, numberOfEventsToTest int) int {
 	eventsFound := make([]bool, numberOfEventsToTest)
 	total := 0
 
@@ -699,5 +746,6 @@ ProcessLoop:
 		}
 	}
 
-	t.Logf("Got all %d out of %d events\n", total, numberOfEventsToTest)
+	t.Logf("Got %d out of %d events\n", total, numberOfEventsToTest)
+	return total
 }

--- a/kinsumer_test.go
+++ b/kinsumer_test.go
@@ -597,20 +597,14 @@ func runSplitTest(t *testing.T, iteratorType ktypes.ShardIteratorType) {
 	require.NoError(t, err, "Problems spamming stream with events")
 
 	foundBefore := readEvents(t, output, numberOfEventsToTest)
-	// Should have some data
-	assert.Greater(t, foundBefore, 0)
 
 	// If using LATEST, we expect to have started at some point after the data came in,
 	// For TRIM_HORIZON, data should be complete.
 	if iteratorType == ktypes.ShardIteratorTypeLatest {
 		assert.Less(t, foundBefore, numberOfEventsToTest)
 	} else if iteratorType == ktypes.ShardIteratorTypeTrimHorizon {
-		assert.Equal(t, foundBefore, numberOfEventsToTest)
+		assert.Equal(t, numberOfEventsToTest, foundBefore)
 	}
-
-	// TODO: Test may have failed before due to timing issue.
-	// Check this iteration of the test on the previous implementation, to see if it does reproduce the problem.
-	// Timing issue not present in TestShardsMerged, so we do have validation of our implementation.
 
 	// Wait a bit for all shard consumption to begin
 	time.Sleep(1000 * time.Millisecond)
@@ -716,22 +710,21 @@ func runSplitTest(t *testing.T, iteratorType ktypes.ShardIteratorType) {
 // This specifically tests bootstrap behavior when ListShards returns existing CLOSED shards
 func TestClosedShardsOnInitialization(t *testing.T) {
 	testCases := []struct {
-		name           string
-		iteratorType   ktypes.ShardIteratorType
-		expectDataLoss bool
+		name         string
+		iteratorType ktypes.ShardIteratorType
 	}{
-		{"TRIM_HORIZON", ktypes.ShardIteratorTypeTrimHorizon, false},
-		{"LATEST", ktypes.ShardIteratorTypeLatest, false},
+		{"TRIM_HORIZON", ktypes.ShardIteratorTypeTrimHorizon},
+		{"LATEST", ktypes.ShardIteratorTypeLatest},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			runClosedShardsOnInitializationTest(t, tc.iteratorType, tc.expectDataLoss)
+			runClosedShardsOnInitializationTest(t, tc.iteratorType)
 		})
 	}
 }
 
-func runClosedShardsOnInitializationTest(t *testing.T, iteratorType ktypes.ShardIteratorType, expectDataLoss bool) {
+func runClosedShardsOnInitializationTest(t *testing.T, iteratorType ktypes.ShardIteratorType) {
 	const (
 		numberOfEventsToTest = 4321
 		numberOfClients      = 3

--- a/kinsumer_test.go
+++ b/kinsumer_test.go
@@ -5,13 +5,14 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/twitchscience/kinsumer/kinsumeriface"
 	"math/rand"
 	"sort"
 	"strconv"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/twitchscience/kinsumer/kinsumeriface"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -600,6 +601,16 @@ func TestSplit(t *testing.T) {
 	})
 	require.NoError(t, err, "Problem merging shards")
 
+	// Send data during the merge operation
+	// This means we also cover bugs to do with timing between the shard action and the consumer
+	const shardActionEvents = 500
+	go func() {
+		// Small delay to ensure merge has started
+		time.Sleep(10 * time.Millisecond)
+		err := spamStream(t, k, shardActionEvents, streamName)
+		require.NoError(t, err, "Problems sending critical data during merge")
+	}()
+
 	require.True(t, shardCount <= shardLimit, "Too many shards")
 	timeout := time.After(time.Second)
 	for {
@@ -624,7 +635,8 @@ func TestSplit(t *testing.T) {
 	err = spamStream(t, k, numberOfEventsToTest, streamName)
 	require.NoError(t, err, "Problems spamming stream with events")
 
-	readEvents(t, output, numberOfEventsToTest)
+	expectedEventsAfterMerge := shardActionEvents + numberOfEventsToTest
+	readEvents(t, output, expectedEventsAfterMerge)
 
 	// Sleep here to wait for stuff to calm down. When running this test
 	// by itself it passes without the sleep but when running all the tests

--- a/kinsumer_test.go
+++ b/kinsumer_test.go
@@ -772,6 +772,17 @@ func runClosedShardsOnInitializationTest(t *testing.T, iteratorType ktypes.Shard
 	})
 	require.NoError(t, err, "Problem merging shards")
 
+	// Send data during the merge operation
+	// This means we also cover bugs to do with timing between the shard action and the consumer
+	const shardActionEvents = 500
+	go func() {
+		// Small delay to ensure merge has started
+		time.Sleep(10 * time.Millisecond)
+		// Index should start where the last spamStream ended, since we're reading both at once in this test
+		err := spamStreamModified(t, k, shardActionEvents, streamName, numberOfEventsToTest)
+		require.NoError(t, err, "Problems sending critical data during merge")
+	}()
+
 	// Wait for merge to complete
 	require.True(t, shardCount <= shardLimit, "Too many shards")
 	timeout := time.After(time.Second)
@@ -856,9 +867,6 @@ func runClosedShardsOnInitializationTest(t *testing.T, iteratorType ktypes.Shard
 		}(i)
 	}
 
-	// Give clients time to initialize and start consuming
-	time.Sleep(2 * time.Second)
-
 	// // DEBUG: Print checkpoints table contents after client initialization
 	// checkpoints, err := loadCheckpoints(d, clients[0].checkpointTableName)
 	// require.NoError(t, err, "Error loading checkpoints for debugging")
@@ -882,13 +890,13 @@ func runClosedShardsOnInitializationTest(t *testing.T, iteratorType ktypes.Shard
 	// t.Logf("=== END CHECKPOINTS DEBUG ===")
 
 	// Read any data that was consumed during initialization
-	foundDuringInit := readEvents(t, output, numberOfEventsToTest)
+	foundDuringInit := readEvents(t, output, numberOfEventsToTest+shardActionEvents)
 
 	// Verify behavior based on iterator type
 	if iteratorType == ktypes.ShardIteratorTypeLatest {
 		assert.Equal(t, 0, foundDuringInit, "Should read no historical data with LATEST")
 	} else {
-		assert.Equal(t, numberOfEventsToTest, foundDuringInit, "Should read all historical data with TRIM_HORIZON")
+		assert.Equal(t, numberOfEventsToTest+shardActionEvents, foundDuringInit, "Should read all historical data with TRIM_HORIZON")
 	}
 
 	// Send new data after clients are initialized

--- a/leader.go
+++ b/leader.go
@@ -123,7 +123,7 @@ func (k *Kinsumer) performLeaderActions() error {
 	if now-shardCache.LastUpdate < k.config.leaderActionFrequency.Nanoseconds() {
 		return nil
 	}
-	curShardIDs, err := loadShardIDsFromKinesis(k.kinesis, k.streamName)
+	curShardIDs, _, _, err := loadShardIDsFromKinesis(k.kinesis, k.streamName)
 	if err != nil {
 		return fmt.Errorf("error loading shard IDs from kinesis: %v", err)
 	}
@@ -276,15 +276,18 @@ func (k *Kinsumer) registerLeadership() (bool, error) {
 	return true, nil
 }
 
-// loadShardIDsFromKinesis returns a sorted slice of shardIDs from kinesis.
+// loadShardIDsFromKinesis returns sorted slices of shardIDs from kinesis.
+// Returns all shards, open shards (EndingSequenceNumber is nil), and closed shards (EndingSequenceNumber is not nil).
 // This function used to use kinesis.DescribeStream, which has a very low throttling limit of 10/s per account.
 // As such, the leader is responsible for caching the shard list.
 // Now that it uses ListShards, you could potentially query the shard list directly from all clients.
 // TODO: Write unit test - needs kinesis mocking
-func loadShardIDsFromKinesis(kin kinsumeriface.KinesisAPI, streamName string) ([]string, error) {
+func loadShardIDsFromKinesis(kin kinsumeriface.KinesisAPI, streamName string) (allShardIDs []string, openShardIDs []string, closedShardIDs []string, err error) {
 	var innerError error
 
-	shardIDs := make([]string, 0)
+	allShardIDs = make([]string, 0)
+	openShardIDs = make([]string, 0)
+	closedShardIDs = make([]string, 0)
 	var token *string
 
 	// Manually page the results since aws-sdk-go has no ListShardsPages.
@@ -308,24 +311,38 @@ func loadShardIDsFromKinesis(kin kinsumeriface.KinesisAPI, streamName string) ([
 		}
 
 		if innerError != nil {
-			return nil, innerError
+			return nil, nil, nil, innerError
 		}
 
 		if err != nil {
-			return nil, err
+			return nil, nil, nil, err
 		}
 
 		for _, s := range res.Shards {
-			shardIDs = append(shardIDs, aws.ToString(s.ShardId))
+			shardID := aws.ToString(s.ShardId)
+			allShardIDs = append(allShardIDs, shardID)
+			
+			// Check if shard is OPEN (EndingSequenceNumber is nil) or CLOSED (not nil)
+			if s.SequenceNumberRange.EndingSequenceNumber == nil {
+				// OPEN shard
+				openShardIDs = append(openShardIDs, shardID)
+			} else {
+				// CLOSED shard
+				closedShardIDs = append(closedShardIDs, shardID)
+			}
 		}
 		if res.NextToken == nil {
 			break
 		}
 		token = res.NextToken
 	}
-	sort.Strings(shardIDs)
+	
+	// Sort all three slices
+	sort.Strings(allShardIDs)
+	sort.Strings(openShardIDs)
+	sort.Strings(closedShardIDs)
 
-	return shardIDs, nil
+	return allShardIDs, openShardIDs, closedShardIDs, nil
 }
 
 // loadShardIDsFromDynamo returns the sorted slice of shardIDs from the metadata table in dynamo.

--- a/leader.go
+++ b/leader.go
@@ -6,9 +6,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/twitchscience/kinsumer/kinsumeriface"
 	"sort"
 	"time"
+
+	"github.com/twitchscience/kinsumer/kinsumeriface"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
@@ -112,6 +113,12 @@ func (k *Kinsumer) performLeaderActions() error {
 		return fmt.Errorf("error loading shard cache from dynamo: %v", err)
 	}
 	cachedShardIDs := shardCache.ShardIDs
+	// If we haven't yet registered shards, wait for next time.
+	// The first client to successfully set up our shard management will set the cache.
+	if len(cachedShardIDs) == 0 {
+		return nil
+	}
+
 	now := time.Now().UnixNano()
 	if now-shardCache.LastUpdate < k.config.leaderActionFrequency.Nanoseconds() {
 		return nil

--- a/mocks/dynamo.go
+++ b/mocks/dynamo.go
@@ -6,11 +6,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
+	"testing"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/twitchscience/kinsumer/kinsumeriface"
-	"testing"
 )
 
 var (
@@ -51,6 +53,9 @@ type mockDynamoCallRecord struct {
 type MockDynamo struct {
 	kinsumeriface.DynamoDBAPI
 
+	// Thread safety
+	mu sync.Mutex
+
 	// Stored data
 	tables map[string][]mockDynamoItem
 
@@ -75,6 +80,8 @@ func (d *MockDynamo) addTable(name string) {
 }
 
 func (d *MockDynamo) recordCall(operation string, in, out interface{}, err error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	d.requests = append(d.requests, mockDynamoCallRecord{
 		operation: operation,
 		input:     in,
@@ -96,6 +103,9 @@ func (d *MockDynamo) PutItem(ctx context.Context, in *dynamodb.PutItemInput, opt
 	if aws.ToString(in.TableName) == mockDynamoErrorTrigger {
 		return nil, errInternalError()
 	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
 
 	tableName := aws.ToString(in.TableName)
 	if _, ok := d.tables[tableName]; !ok {
@@ -132,6 +142,9 @@ func (d *MockDynamo) GetItem(ctx context.Context, in *dynamodb.GetItemInput, opt
 	if aws.ToString(in.TableName) == mockDynamoErrorTrigger {
 		return nil, errInternalError()
 	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
 
 	tableName := aws.ToString(in.TableName)
 	if _, ok := d.tables[tableName]; !ok {

--- a/mocks/kinesis.go
+++ b/mocks/kinesis.go
@@ -1,0 +1,351 @@
+// Copyright (c) 2016 Twitch Interactive
+
+package mocks
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/kinesis"
+	"github.com/aws/aws-sdk-go-v2/service/kinesis/types"
+	"github.com/twitchscience/kinsumer/kinsumeriface"
+)
+
+// mockKinesisCallRecord tracks individual calls to MockKinesis methods
+type mockKinesisCallRecord struct {
+	operation string
+	shardID   string
+	startTime time.Time
+	endTime   time.Time
+	err       error
+}
+
+// MockKinesis mocks the Kinesis API in memory with call tracking and concurrency monitoring
+type MockKinesis struct {
+	kinsumeriface.KinesisAPI
+
+	mu sync.Mutex
+
+	// Call tracking
+	calls           []mockKinesisCallRecord
+	activeCalls     int
+	maxConcurrent   int
+	totalCalls      int
+
+	// Configuration
+	delay           time.Duration
+	shouldError     bool
+	errorTriggerShard string
+	useGenericError bool
+	shouldErrorOnGetShardIterator bool
+
+	// Mock data
+	shards          map[string]*mockShard
+	streamStatus    string
+}
+
+type mockShard struct {
+	shardID    string
+	records    []types.Record
+	iterator   string
+	nextIterator string
+	closed     bool
+}
+
+// NewMockKinesis creates a new MockKinesis with the specified shards
+func NewMockKinesis(shardIDs []string) *MockKinesis {
+	mk := &MockKinesis{
+		calls:        make([]mockKinesisCallRecord, 0),
+		shards:       make(map[string]*mockShard),
+		streamStatus: "ACTIVE",
+	}
+
+	// Create mock shards
+	for _, shardID := range shardIDs {
+		mk.shards[shardID] = &mockShard{
+			shardID:      shardID,
+			records:      make([]types.Record, 0),
+			iterator:     "iter-" + shardID + "-0",
+			nextIterator: "iter-" + shardID + "-1",
+			closed:       false,
+		}
+		
+		// Add some mock records for each shard
+		for j := 0; j < 10; j++ {
+			recordData := []byte("record-" + shardID + "-" + fmt.Sprintf("%d", j))
+			mk.shards[shardID].records = append(mk.shards[shardID].records, types.Record{
+				Data:           recordData,
+				PartitionKey:   aws.String("partition-" + shardID),
+				SequenceNumber: aws.String("seq-" + shardID + "-" + fmt.Sprintf("%d", j)),
+			})
+		}
+	}
+
+	return mk
+}
+
+// SetDelay configures artificial delay for GetRecords calls
+func (mk *MockKinesis) SetDelay(delay time.Duration) {
+	mk.mu.Lock()
+	defer mk.mu.Unlock()
+	mk.delay = delay
+}
+
+// SetError configures GetRecords to return errors for a specific shard
+func (mk *MockKinesis) SetError(shardID string, shouldError bool) {
+	mk.mu.Lock()
+	defer mk.mu.Unlock()
+	mk.errorTriggerShard = shardID
+	mk.shouldError = shouldError
+}
+
+// SetGenericError configures GetRecords to return a generic error (not ExpiredIteratorException)
+func (mk *MockKinesis) SetGenericError(shardID string) {
+	mk.mu.Lock()
+	defer mk.mu.Unlock()
+	mk.errorTriggerShard = shardID
+	mk.shouldError = true
+	mk.useGenericError = true
+}
+
+// SetEmptyRecords configures GetRecords to return empty records for a specific shard
+func (mk *MockKinesis) SetEmptyRecords(shardID string) {
+	mk.mu.Lock()
+	defer mk.mu.Unlock()
+	if shard, exists := mk.shards[shardID]; exists {
+		shard.records = []types.Record{} // Clear all records
+	}
+}
+
+// SetBothGetRecordsAndGetShardIteratorErrors configures both GetRecords and GetShardIterator to fail
+func (mk *MockKinesis) SetBothGetRecordsAndGetShardIteratorErrors(shardID string) {
+	mk.mu.Lock()
+	defer mk.mu.Unlock()
+	mk.errorTriggerShard = shardID
+	mk.shouldError = true
+	mk.useGenericError = false // Use ExpiredIteratorException for GetRecords
+	mk.shouldErrorOnGetShardIterator = true
+}
+
+
+// GetMaxConcurrentCalls returns the maximum concurrent calls observed
+func (mk *MockKinesis) GetMaxConcurrentCalls() int {
+	mk.mu.Lock()
+	defer mk.mu.Unlock()
+	return mk.maxConcurrent
+}
+
+// GetCurrentActiveCalls returns the current number of active calls
+func (mk *MockKinesis) GetCurrentActiveCalls() int {
+	mk.mu.Lock()
+	defer mk.mu.Unlock()
+	return mk.activeCalls
+}
+
+// GetTotalCalls returns total number of GetRecords calls made
+func (mk *MockKinesis) GetTotalCalls() int {
+	mk.mu.Lock()
+	defer mk.mu.Unlock()
+	return mk.totalCalls
+}
+
+// WaitForConcurrentCalls blocks until the specified number of concurrent calls is reached
+func (mk *MockKinesis) WaitForConcurrentCalls(targetCount int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		mk.mu.Lock()
+		current := mk.activeCalls
+		mk.mu.Unlock()
+		
+		if current >= targetCount {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false
+}
+
+// recordCall tracks a method call
+func (mk *MockKinesis) recordCall(operation, shardID string, err error) {
+	call := mockKinesisCallRecord{
+		operation: operation,
+		shardID:   shardID,
+		startTime: time.Now(),
+		err:       err,
+	}
+	mk.calls = append(mk.calls, call)
+}
+
+// GetShardIterator mocks the Kinesis GetShardIterator operation
+func (mk *MockKinesis) GetShardIterator(ctx context.Context, input *kinesis.GetShardIteratorInput, optFns ...func(*kinesis.Options)) (*kinesis.GetShardIteratorOutput, error) {
+	mk.mu.Lock()
+	defer mk.mu.Unlock()
+
+	shardID := aws.ToString(input.ShardId)
+	
+	// Check for configured errors
+	if mk.shouldErrorOnGetShardIterator && shardID == mk.errorTriggerShard {
+		mk.recordCall("GetShardIterator", shardID, fmt.Errorf("simulated GetShardIterator error"))
+		return nil, fmt.Errorf("simulated GetShardIterator error")
+	}
+	
+	mk.recordCall("GetShardIterator", shardID, nil)
+
+	shard, exists := mk.shards[shardID]
+	if !exists {
+		return nil, &types.ResourceNotFoundException{Message: aws.String("Shard not found")}
+	}
+
+	return &kinesis.GetShardIteratorOutput{
+		ShardIterator: &shard.iterator,
+	}, nil
+}
+
+// GetRecords mocks the Kinesis GetRecords operation with concurrency tracking
+func (mk *MockKinesis) GetRecords(ctx context.Context, input *kinesis.GetRecordsInput, optFns ...func(*kinesis.Options)) (*kinesis.GetRecordsOutput, error) {
+	// Track call start
+	mk.mu.Lock()
+	mk.activeCalls++
+	if mk.activeCalls > mk.maxConcurrent {
+		mk.maxConcurrent = mk.activeCalls
+	}
+	mk.totalCalls++
+	delay := mk.delay
+	shouldError := mk.shouldError
+	errorTrigger := mk.errorTriggerShard
+	useGenericError := mk.useGenericError
+	mk.mu.Unlock()
+
+	// Extract shard ID from iterator (simplified)
+	iterator := aws.ToString(input.ShardIterator)
+	var shardID string
+	if len(iterator) > 5 && iterator[:5] == "iter-" {
+		// Extract shard ID from iterator format "iter-{shardID}-{seq}"
+		parts := iterator[5:] // Remove "iter-" prefix
+		if dashIndex := len(parts) - 2; dashIndex > 0 { // Find last dash
+			shardID = parts[:dashIndex]
+		}
+	}
+
+	// Ensure we decrement active calls when done
+	defer func() {
+		mk.mu.Lock()
+		mk.activeCalls--
+		mk.mu.Unlock()
+	}()
+
+	// Apply artificial delay if configured
+	if delay > 0 {
+		time.Sleep(delay)
+	}
+
+	// Check for configured errors
+	if shouldError && shardID == errorTrigger {
+		mk.mu.Lock()
+		if useGenericError {
+			mk.recordCall("GetRecords", shardID, fmt.Errorf("simulated kinesis error"))
+			mk.mu.Unlock()
+			return nil, fmt.Errorf("simulated kinesis error")
+		} else {
+			mk.recordCall("GetRecords", shardID, &types.ExpiredIteratorException{})
+			mk.mu.Unlock()
+			return nil, &types.ExpiredIteratorException{Message: aws.String("Iterator expired")}
+		}
+	}
+
+	mk.mu.Lock()
+	defer mk.mu.Unlock()
+	
+	mk.recordCall("GetRecords", shardID, nil)
+
+	shard, exists := mk.shards[shardID]
+	if !exists {
+		return &kinesis.GetRecordsOutput{
+			Records:           []types.Record{},
+			NextShardIterator: nil,
+			MillisBehindLatest: aws.Int64(0),
+		}, nil
+	}
+
+	// Return some records and update iterator
+	var records []types.Record
+	if len(shard.records) > 0 && !shard.closed {
+		// Return first few records
+		recordCount := len(shard.records)
+		if recordCount > 3 {
+			recordCount = 3 // Return max 3 records per call
+		}
+		records = shard.records[:recordCount]
+		shard.records = shard.records[recordCount:]
+	}
+
+	var nextIterator *string
+	if len(shard.records) > 0 && !shard.closed {
+		nextIterator = &shard.nextIterator
+		// Update iterator for next call
+		shard.iterator = shard.nextIterator
+		shard.nextIterator = shard.nextIterator + "-next"
+	} else {
+		// End of shard
+		nextIterator = nil
+	}
+
+	return &kinesis.GetRecordsOutput{
+		Records:           records,
+		NextShardIterator: nextIterator,
+		MillisBehindLatest: aws.Int64(100),
+	}, nil
+}
+
+// DescribeStream mocks the Kinesis DescribeStream operation
+func (mk *MockKinesis) DescribeStream(ctx context.Context, input *kinesis.DescribeStreamInput, optFns ...func(*kinesis.Options)) (*kinesis.DescribeStreamOutput, error) {
+	mk.mu.Lock()
+	defer mk.mu.Unlock()
+
+	mk.recordCall("DescribeStream", "", nil)
+
+	var shards []types.Shard
+	for shardID := range mk.shards {
+		shards = append(shards, types.Shard{
+			ShardId: aws.String(shardID),
+			HashKeyRange: &types.HashKeyRange{
+				StartingHashKey: aws.String("0"),
+				EndingHashKey:   aws.String("1000"),
+			},
+			SequenceNumberRange: &types.SequenceNumberRange{
+				StartingSequenceNumber: aws.String("0"),
+			},
+		})
+	}
+
+	return &kinesis.DescribeStreamOutput{
+		StreamDescription: &types.StreamDescription{
+			StreamName:   input.StreamName,
+			StreamStatus: types.StreamStatus(mk.streamStatus),
+			Shards:       shards,
+		},
+	}, nil
+}
+
+// Implement other required methods as no-ops for interface compliance
+
+func (mk *MockKinesis) CreateStream(ctx context.Context, input *kinesis.CreateStreamInput, optFns ...func(*kinesis.Options)) (*kinesis.CreateStreamOutput, error) {
+	return &kinesis.CreateStreamOutput{}, nil
+}
+
+func (mk *MockKinesis) DeleteStream(ctx context.Context, input *kinesis.DeleteStreamInput, optFns ...func(*kinesis.Options)) (*kinesis.DeleteStreamOutput, error) {
+	return &kinesis.DeleteStreamOutput{}, nil
+}
+
+func (mk *MockKinesis) PutRecords(ctx context.Context, input *kinesis.PutRecordsInput, optFns ...func(*kinesis.Options)) (*kinesis.PutRecordsOutput, error) {
+	return &kinesis.PutRecordsOutput{
+		FailedRecordCount: aws.Int32(0),
+	}, nil
+}
+
+func (mk *MockKinesis) MergeShards(ctx context.Context, input *kinesis.MergeShardsInput, optFns ...func(*kinesis.Options)) (*kinesis.MergeShardsOutput, error) {
+	return &kinesis.MergeShardsOutput{}, nil
+}

--- a/noopstatreceiver.go
+++ b/noopstatreceiver.go
@@ -19,7 +19,7 @@ func (*NoopStatReceiver) EventToClient(inserted, retrieved time.Time) {}
 func (*NoopStatReceiver) EventsFromKinesis(num int, shardID string, lag time.Duration) {}
 
 // RecordsInMemory implementation that doesn't do anything
-func (*NoopStatReceiver) RecordsInMemory(count int) {}
+func (*NoopStatReceiver) RecordsInMemory(count int64) {}
 
 // RecordsInMemoryBytes implementation that doesn't do anything
 func (*NoopStatReceiver) RecordsInMemoryBytes(bytes int64) {}

--- a/noopstatreceiver.go
+++ b/noopstatreceiver.go
@@ -20,3 +20,6 @@ func (*NoopStatReceiver) EventsFromKinesis(num int, shardID string, lag time.Dur
 
 // RecordsInMemory implementation that doesn't do anything
 func (*NoopStatReceiver) RecordsInMemory(count int) {}
+
+// RecordsInMemoryBytes implementation that doesn't do anything
+func (*NoopStatReceiver) RecordsInMemoryBytes(bytes int64) {}

--- a/noopstatreceiver.go
+++ b/noopstatreceiver.go
@@ -17,3 +17,6 @@ func (*NoopStatReceiver) EventToClient(inserted, retrieved time.Time) {}
 
 // EventsFromKinesis implementation that doesn't do anything
 func (*NoopStatReceiver) EventsFromKinesis(num int, shardID string, lag time.Duration) {}
+
+// RecordsInMemory implementation that doesn't do anything
+func (*NoopStatReceiver) RecordsInMemory(count int) {}

--- a/shard_consumer.go
+++ b/shard_consumer.go
@@ -23,19 +23,30 @@ const (
 )
 
 // getShardIterator gets a shard iterator after the last sequence number we read or at the start of the stream
-func getShardIterator(k kinsumeriface.KinesisAPI, streamName string, shardID string, sequenceNumber string, iteratorStartTimestamp *time.Time) (string, error) {
+// iteratorType specifies the type to use when sequenceNumber is empty
+func getShardIterator(k kinsumeriface.KinesisAPI, streamName string, shardID string, sequenceNumber string, iteratorStartTimestamp *time.Time, iteratorType ktypes.ShardIteratorType) (string, error) {
 	shardIteratorType := ktypes.ShardIteratorTypeAfterSequenceNumber
 
 	// If we do not have a sequenceNumber yet we need to get a shardIterator
-	// from the horizon
+	// based on the configured iterator type
 	ps := aws.String(sequenceNumber)
-	if sequenceNumber == "" && iteratorStartTimestamp != nil {
-		shardIteratorType = ktypes.ShardIteratorTypeAtTimestamp
-		ps = nil
-	} else if sequenceNumber == "" {
-		shardIteratorType = ktypes.ShardIteratorTypeTrimHorizon
-		ps = nil
+	if sequenceNumber == "" {
+		// Use configured iterator type for new checkpoints
+		switch iteratorType {
+		case ktypes.ShardIteratorTypeTrimHorizon:
+			shardIteratorType = ktypes.ShardIteratorTypeTrimHorizon
+			ps = nil
+		case ktypes.ShardIteratorTypeLatest:
+			shardIteratorType = ktypes.ShardIteratorTypeLatest
+			ps = nil
+		case ktypes.ShardIteratorTypeAtTimestamp:
+			shardIteratorType = ktypes.ShardIteratorTypeAtTimestamp
+			ps = nil
+		default:
+			return "", fmt.Errorf("unsupported iterator type: %v", iteratorType)
+		}
 	} else if sequenceNumber == "LATEST" {
+		// Backward compatibility: support "LATEST" as sequence number
 		shardIteratorType = ktypes.ShardIteratorTypeLatest
 		ps = nil
 	}
@@ -143,7 +154,7 @@ func (k *Kinsumer) consume(shardID string) {
 	}()
 
 	// Get the starting shard iterator
-	iterator, err := getShardIterator(k.kinesis, k.streamName, shardID, sequenceNumber, k.config.iteratorStartTimestamp)
+	iterator, err := getShardIterator(k.kinesis, k.streamName, shardID, sequenceNumber, k.config.iteratorStartTimestamp, k.config.iteratorType)
 	if err != nil {
 		k.shardErrors <- shardConsumerError{shardID: shardID, action: "getShardIterator", err: err}
 		return
@@ -201,7 +212,7 @@ mainloop:
 				var eie *ktypes.ExpiredIteratorException
 				if errors.As(err, &eie) {
 					k.config.logger.Log("Got error: %s %s %s", eie.ErrorCode(), eie.ErrorMessage(), origErrStr)
-					newIterator, ierr := getShardIterator(k.kinesis, k.streamName, shardID, lastSeqToCheckp, nil)
+					newIterator, ierr := getShardIterator(k.kinesis, k.streamName, shardID, lastSeqToCheckp, nil, k.config.iteratorType)
 					if ierr != nil {
 						k.shardErrors <- shardConsumerError{shardID: shardID, action: "getShardIterator", err: err}
 						return

--- a/shard_consumer.go
+++ b/shard_consumer.go
@@ -194,6 +194,18 @@ mainloop:
 			continue mainloop
 		}
 
+		// Acquire semaphore to limit concurrent shard record fetching
+		if k.shardSemaphore != nil {
+			k.shardSemaphore <- struct{}{} // May block if limit reached
+		}
+
+		// Helper function for safe semaphore release
+		releaseSemaphore := func() {
+			if k.shardSemaphore != nil {
+				<-k.shardSemaphore
+			}
+		}
+
 		// Get records from kinesis
 		records, next, lag, err := getRecords(k.kinesis, iterator, k.config.getRecordsLimit)
 
@@ -208,15 +220,18 @@ mainloop:
 					k.config.logger.Log("Got error: %s %s %s", eie.ErrorCode(), eie.ErrorMessage(), origErrStr)
 					newIterator, ierr := getShardIterator(k.kinesis, k.streamName, shardID, lastSeqToCheckp, nil, k.config.iteratorType)
 					if ierr != nil {
+						releaseSemaphore()
 						k.shardErrors <- shardConsumerError{shardID: shardID, action: "getShardIterator", err: err}
 						return
 					}
 					iterator = newIterator
 
 					// retry infinitely after expired iterator is renewed successfully
+					releaseSemaphore()
 					continue mainloop
 				}
 			}
+			releaseSemaphore()
 			k.shardErrors <- shardConsumerError{shardID: shardID, action: "getRecords", err: err}
 			return
 		}
@@ -256,6 +271,9 @@ mainloop:
 			// Update the last sequence number we saw, in case we reached the end of the stream.
 			lastSeqNum = aws.ToString(records[len(records)-1].SequenceNumber)
 		}
+		
+		// Release semaphore after successfully processing all records from this batch
+		releaseSemaphore()
 		iterator = next
 	}
 	// Handle checkpointer updates which occur after a stop request comes in (whose originating records were before)

--- a/shard_consumer.go
+++ b/shard_consumer.go
@@ -15,12 +15,6 @@ import (
 	smithy "github.com/aws/smithy-go"
 )
 
-const (
-	// getRecordsLimit is the max number of records in a single request. This effectively limits the
-	// total processing speed to getRecordsLimit*5/n where n is the number of parallel clients trying
-	// to consume from the same kinesis stream
-	getRecordsLimit = 10000 // 10,000 is the max according to the docs
-)
 
 // getShardIterator gets a shard iterator after the last sequence number we read or at the start of the stream
 // iteratorType specifies the type to use when sequenceNumber is empty
@@ -65,9 +59,9 @@ func getShardIterator(k kinsumeriface.KinesisAPI, streamName string, shardID str
 }
 
 // getRecords returns the next records and shard iterator from the given shard iterator
-func getRecords(k kinsumeriface.KinesisAPI, iterator string) (records []ktypes.Record, nextIterator string, lag time.Duration, err error) {
+func getRecords(k kinsumeriface.KinesisAPI, iterator string, limit int) (records []ktypes.Record, nextIterator string, lag time.Duration, err error) {
 	params := &kinesis.GetRecordsInput{
-		Limit:         aws.Int32(getRecordsLimit),
+		Limit:         aws.Int32(int32(limit)),
 		ShardIterator: aws.String(iterator),
 	}
 
@@ -201,7 +195,7 @@ mainloop:
 		}
 
 		// Get records from kinesis
-		records, next, lag, err := getRecords(k.kinesis, iterator)
+		records, next, lag, err := getRecords(k.kinesis, iterator, k.config.getRecordsLimit)
 
 		if err != nil {
 			var ae smithy.APIError

--- a/shard_consumer.go
+++ b/shard_consumer.go
@@ -15,6 +15,15 @@ import (
 	smithy "github.com/aws/smithy-go"
 )
 
+// batchProcessResult represents the flow control decision from processing a batch of records
+type batchProcessResult int
+
+const (
+	batchSuccess  batchProcessResult = iota // continue normal processing
+	batchContinue                           // equivalent to continue mainloop
+	batchBreak                              // equivalent to break mainloop
+	batchError                              // error occurred, exit function
+)
 
 // getShardIterator gets a shard iterator after the last sequence number we read or at the start of the stream
 // iteratorType specifies the type to use when sequenceNumber is empty
@@ -109,6 +118,107 @@ func (k *Kinsumer) captureShard(shardID string) (*checkpointer, error) {
 	}
 }
 
+// processRecordsBatch handles getting and processing a batch of records with automatic semaphore management
+func (k *Kinsumer) processRecordsBatch(iterator string, shardID string, checkpointer *checkpointer, lastSeqToCheckp *string, lastSeqNum *string, commitTicker *time.Ticker) (nextIterator string, result batchProcessResult, err error) {
+	// Acquire semaphore to limit concurrent shard record fetching
+	if k.shardSemaphore != nil {
+		k.shardSemaphore <- struct{}{} // May block if limit reached
+	}
+
+	// Ensure semaphore is released regardless of how this function exits
+	defer func() {
+		if k.shardSemaphore != nil {
+			<-k.shardSemaphore
+		}
+	}()
+
+	// Get records from kinesis
+	records, next, lag, err := getRecords(k.kinesis, iterator, k.config.getRecordsLimit)
+
+	if err != nil {
+		var ae smithy.APIError
+		if errors.As(err, &ae) {
+			origErrStr := fmt.Sprintf("(%s) ", ae)
+			k.config.logger.Log("Got error: %s %s %s", ae.ErrorCode(), ae.ErrorMessage(), origErrStr)
+
+			var eie *ktypes.ExpiredIteratorException
+			if errors.As(err, &eie) {
+				k.config.logger.Log("Got error: %s %s %s", eie.ErrorCode(), eie.ErrorMessage(), origErrStr)
+				newIterator, ierr := getShardIterator(k.kinesis, k.streamName, shardID, *lastSeqToCheckp, nil, k.config.iteratorType)
+				if ierr != nil {
+					return "", batchError, fmt.Errorf("getShardIterator after expired iterator: %w", ierr)
+				}
+				// retry infinitely after expired iterator is renewed successfully
+				return newIterator, batchContinue, nil
+			}
+		}
+		return "", batchError, fmt.Errorf("getRecords: %w", err)
+	}
+
+	// Put all the records we got onto the channel
+	k.config.stats.EventsFromKinesis(len(records), shardID, lag)
+	k.metricsManager.updateMetric(RecordsIncrement, int64(len(records)))
+	
+	// Calculate total payload bytes in the batch
+	totalBytes := int64(0)
+	for _, record := range records {
+		totalBytes += int64(len(record.Data))
+	}
+	k.metricsManager.updateMetric(BytesIncrement, totalBytes)
+	
+	// Track records for cleanup in case of early return
+	recordsToCleanup := int64(len(records))
+	bytesToCleanup := totalBytes
+	defer func() {
+		// Decrement any records that weren't successfully processed
+		if recordsToCleanup > 0 {
+			k.metricsManager.updateMetric(RecordsDecrement, recordsToCleanup)
+		}
+		if bytesToCleanup > 0 {
+			k.metricsManager.updateMetric(BytesDecrement, bytesToCleanup)
+		}
+	}()
+	
+	if len(records) > 0 {
+		retrievedAt := time.Now()
+		for _, record := range records {
+			// Loop until we stop or the record is consumed, checkpointing if necessary.
+			recordPayloadBytes := int64(len(record.Data))
+		RecordLoop:
+			for {
+				select {
+				case <-commitTicker.C:
+					finishCommitted, err := checkpointer.commit(k.config.commitFrequency)
+					if err != nil {
+						return "", batchError, fmt.Errorf("checkpointer.commit: %w", err)
+					}
+					if finishCommitted {
+						return "", batchSuccess, nil
+					}
+				case <-k.stop:
+					return "", batchBreak, nil
+				case k.records <- &consumedRecord{
+					record:       &record,
+					checkpointer: checkpointer,
+					retrievedAt:  retrievedAt,
+					payloadBytes: recordPayloadBytes,
+				}:
+					recordsToCleanup-- // Record successfully sent to channel
+					bytesToCleanup -= recordPayloadBytes // Decrement bytes for successfully sent record
+					checkpointer.lastRecordPassed = time.Now() // Mark the time so we don't retain shards when we're too slow to do so
+					*lastSeqToCheckp = aws.ToString(record.SequenceNumber)
+					break RecordLoop
+				}
+			}
+		}
+
+		// Update the last sequence number we saw, in case we reached the end of the stream.
+		*lastSeqNum = aws.ToString(records[len(records)-1].SequenceNumber)
+	}
+	
+	return next, batchSuccess, nil
+}
+
 // consume is a blocking call that captures then consumes the given shard in a loop.
 // It is also responsible for writing out the checkpoint updates to dynamo.
 // TODO: There are no tests for this file. Not sure how to even unit test this.
@@ -194,113 +304,26 @@ mainloop:
 			continue mainloop
 		}
 
-		// Acquire semaphore to limit concurrent shard record fetching
-		if k.shardSemaphore != nil {
-			k.shardSemaphore <- struct{}{} // May block if limit reached
-		}
-
-		// Helper function for safe semaphore release
-		releaseSemaphore := func() {
-			if k.shardSemaphore != nil {
-				<-k.shardSemaphore
-			}
-		}
-
-		// Get records from kinesis
-		records, next, lag, err := getRecords(k.kinesis, iterator, k.config.getRecordsLimit)
-
+		// Process records batch with automatic semaphore management
+		nextIterator, result, err := k.processRecordsBatch(iterator, shardID, checkpointer, &lastSeqToCheckp, &lastSeqNum, commitTicker)
 		if err != nil {
-			var ae smithy.APIError
-			if errors.As(err, &ae) {
-				origErrStr := fmt.Sprintf("(%s) ", ae)
-				k.config.logger.Log("Got error: %s %s %s", ae.ErrorCode(), ae.ErrorMessage(), origErrStr)
-
-				var eie *ktypes.ExpiredIteratorException
-				if errors.As(err, &eie) {
-					k.config.logger.Log("Got error: %s %s %s", eie.ErrorCode(), eie.ErrorMessage(), origErrStr)
-					newIterator, ierr := getShardIterator(k.kinesis, k.streamName, shardID, lastSeqToCheckp, nil, k.config.iteratorType)
-					if ierr != nil {
-						releaseSemaphore()
-						k.shardErrors <- shardConsumerError{shardID: shardID, action: "getShardIterator", err: err}
-						return
-					}
-					iterator = newIterator
-
-					// retry infinitely after expired iterator is renewed successfully
-					releaseSemaphore()
-					continue mainloop
-				}
-			}
-			releaseSemaphore()
-			k.shardErrors <- shardConsumerError{shardID: shardID, action: "getRecords", err: err}
+			k.shardErrors <- shardConsumerError{shardID: shardID, action: "processRecordsBatch", err: err}
 			return
 		}
-
-		// Put all the records we got onto the channel
-		k.config.stats.EventsFromKinesis(len(records), shardID, lag)
-		k.metricsManager.updateMetric(RecordsIncrement, int64(len(records)))
 		
-		// Calculate total payload bytes in the batch
-		totalBytes := int64(0)
-		for _, record := range records {
-			totalBytes += int64(len(record.Data))
-		}
-		k.metricsManager.updateMetric(BytesIncrement, totalBytes)
-		
-		// Track records for cleanup in case of early return
-		recordsToCleanup := int64(len(records))
-		bytesToCleanup := totalBytes
-		defer func() {
-			// Decrement any records that weren't successfully processed
-			if recordsToCleanup > 0 {
-				k.metricsManager.updateMetric(RecordsDecrement, recordsToCleanup)
-			}
-			if bytesToCleanup > 0 {
-				k.metricsManager.updateMetric(BytesDecrement, bytesToCleanup)
-			}
-		}()
-		
-		if len(records) > 0 {
-			retrievedAt := time.Now()
-			for _, record := range records {
-				// Loop until we stop or the record is consumed, checkpointing if necessary.
-				recordPayloadBytes := int64(len(record.Data))
-			RecordLoop:
-				for {
-					select {
-					case <-commitTicker.C:
-						finishCommitted, err := checkpointer.commit(k.config.commitFrequency)
-						if err != nil {
-							k.shardErrors <- shardConsumerError{shardID: shardID, action: "checkpointer.commit", err: err}
-							return
-						}
-						if finishCommitted {
-							return
-						}
-					case <-k.stop:
-						break mainloop
-					case k.records <- &consumedRecord{
-						record:       &record,
-						checkpointer: checkpointer,
-						retrievedAt:  retrievedAt,
-						payloadBytes: recordPayloadBytes,
-					}:
-						recordsToCleanup-- // Record successfully sent to channel
-						bytesToCleanup -= recordPayloadBytes // Decrement bytes for successfully sent record
-						checkpointer.lastRecordPassed = time.Now() // Mark the time so we don't retain shards when we're too slow to do so
-						lastSeqToCheckp = aws.ToString(record.SequenceNumber)
-						break RecordLoop
-					}
-				}
-			}
-
-			// Update the last sequence number we saw, in case we reached the end of the stream.
-			lastSeqNum = aws.ToString(records[len(records)-1].SequenceNumber)
+		// Handle flow control based on batch processing result
+		switch result {
+		case batchBreak:
+			break mainloop
+		case batchContinue:
+			continue mainloop
+		case batchError:
+			return // Error already sent to shardErrors channel above
+		case batchSuccess:
+			// Continue to next iteration normally
 		}
 		
-		// Release semaphore after successfully processing all records from this batch
-		releaseSemaphore()
-		iterator = next
+		iterator = nextIterator
 	}
 	// Handle checkpointer updates which occur after a stop request comes in (whose originating records were before)
 

--- a/shard_consumer.go
+++ b/shard_consumer.go
@@ -26,28 +26,18 @@ const (
 )
 
 // getShardIterator gets a shard iterator after the last sequence number we read or at the start of the stream
-// iteratorType specifies the type to use when sequenceNumber is empty
-func getShardIterator(k kinsumeriface.KinesisAPI, streamName string, shardID string, sequenceNumber string, iteratorStartTimestamp *time.Time, iteratorType ktypes.ShardIteratorType) (string, error) {
+func getShardIterator(k kinsumeriface.KinesisAPI, streamName string, shardID string, sequenceNumber string, iteratorStartTimestamp *time.Time) (string, error) {
 	shardIteratorType := ktypes.ShardIteratorTypeAfterSequenceNumber
 
 	// If we do not have a sequenceNumber yet we need to get a shardIterator
-	// based on the configured iterator type
+	// from the horizon
 	ps := aws.String(sequenceNumber)
-	if sequenceNumber == "" {
-		// Use configured iterator type for new checkpoints
-		switch iteratorType {
-		case ktypes.ShardIteratorTypeTrimHorizon:
-			shardIteratorType = ktypes.ShardIteratorTypeTrimHorizon
-			ps = nil
-		case ktypes.ShardIteratorTypeLatest:
-			shardIteratorType = ktypes.ShardIteratorTypeLatest
-			ps = nil
-		case ktypes.ShardIteratorTypeAtTimestamp:
-			shardIteratorType = ktypes.ShardIteratorTypeAtTimestamp
-			ps = nil
-		default:
-			return "", fmt.Errorf("unsupported iterator type: %v", iteratorType)
-		}
+	if sequenceNumber == "" && iteratorStartTimestamp != nil {
+		shardIteratorType = ktypes.ShardIteratorTypeAtTimestamp
+		ps = nil
+	} else if sequenceNumber == "" {
+		shardIteratorType = ktypes.ShardIteratorTypeTrimHorizon
+		ps = nil
 	} else if sequenceNumber == "LATEST" {
 		// Backward compatibility: support "LATEST" as sequence number
 		shardIteratorType = ktypes.ShardIteratorTypeLatest
@@ -144,7 +134,7 @@ func (k *Kinsumer) processRecordsBatch(iterator string, shardID string, checkpoi
 			var eie *ktypes.ExpiredIteratorException
 			if errors.As(err, &eie) {
 				k.config.logger.Log("Got error: %s %s %s", eie.ErrorCode(), eie.ErrorMessage(), origErrStr)
-				newIterator, ierr := getShardIterator(k.kinesis, k.streamName, shardID, *lastSeqToCheckp, nil, k.config.iteratorType)
+				newIterator, ierr := getShardIterator(k.kinesis, k.streamName, shardID, *lastSeqToCheckp, nil)
 				if ierr != nil {
 					return "", batchError, fmt.Errorf("getShardIterator after expired iterator: %w", ierr)
 				}
@@ -258,7 +248,7 @@ func (k *Kinsumer) consume(shardID string) {
 	}()
 
 	// Get the starting shard iterator
-	iterator, err := getShardIterator(k.kinesis, k.streamName, shardID, sequenceNumber, k.config.iteratorStartTimestamp, k.config.iteratorType)
+	iterator, err := getShardIterator(k.kinesis, k.streamName, shardID, sequenceNumber, k.config.iteratorStartTimestamp)
 	if err != nil {
 		k.shardErrors <- shardConsumerError{shardID: shardID, action: "getShardIterator", err: err}
 		return

--- a/shard_consumer.go
+++ b/shard_consumer.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/twitchscience/kinsumer/kinsumeriface"
-	"sync/atomic"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -239,14 +238,14 @@ mainloop:
 
 		// Put all the records we got onto the channel
 		k.config.stats.EventsFromKinesis(len(records), shardID, lag)
-		atomic.AddInt64(&k.recordsInMemoryCount, int64(len(records)))
+		k.metricsManager.updateMetric(RecordsIncrement, int64(len(records)))
 		
 		// Calculate total payload bytes in the batch
 		totalBytes := int64(0)
 		for _, record := range records {
 			totalBytes += int64(len(record.Data))
 		}
-		atomic.AddInt64(&k.bytesInMemoryCount, totalBytes)
+		k.metricsManager.updateMetric(BytesIncrement, totalBytes)
 		
 		// Track records for cleanup in case of early return
 		recordsToCleanup := int64(len(records))
@@ -254,10 +253,10 @@ mainloop:
 		defer func() {
 			// Decrement any records that weren't successfully processed
 			if recordsToCleanup > 0 {
-				atomic.AddInt64(&k.recordsInMemoryCount, -recordsToCleanup)
+				k.metricsManager.updateMetric(RecordsDecrement, recordsToCleanup)
 			}
 			if bytesToCleanup > 0 {
-				atomic.AddInt64(&k.bytesInMemoryCount, -bytesToCleanup)
+				k.metricsManager.updateMetric(BytesDecrement, bytesToCleanup)
 			}
 		}()
 		

--- a/shard_consumer.go
+++ b/shard_consumer.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/twitchscience/kinsumer/kinsumeriface"
+	"sync/atomic"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -238,6 +239,17 @@ mainloop:
 
 		// Put all the records we got onto the channel
 		k.config.stats.EventsFromKinesis(len(records), shardID, lag)
+		atomic.AddInt64(&k.recordsInMemoryCount, int64(len(records)))
+		
+		// Track records for cleanup in case of early return
+		recordsToCleanup := int64(len(records))
+		defer func() {
+			// Decrement any records that weren't successfully processed
+			if recordsToCleanup > 0 {
+				atomic.AddInt64(&k.recordsInMemoryCount, -recordsToCleanup)
+			}
+		}()
+		
 		if len(records) > 0 {
 			retrievedAt := time.Now()
 			for _, record := range records {
@@ -261,6 +273,7 @@ mainloop:
 						checkpointer: checkpointer,
 						retrievedAt:  retrievedAt,
 					}:
+						recordsToCleanup-- // Record successfully sent to channel
 						checkpointer.lastRecordPassed = time.Now() // Mark the time so we don't retain shards when we're too slow to do so
 						lastSeqToCheckp = aws.ToString(record.SequenceNumber)
 						break RecordLoop

--- a/shard_consumer.go
+++ b/shard_consumer.go
@@ -241,20 +241,32 @@ mainloop:
 		k.config.stats.EventsFromKinesis(len(records), shardID, lag)
 		atomic.AddInt64(&k.recordsInMemoryCount, int64(len(records)))
 		
+		// Calculate total payload bytes in the batch
+		totalBytes := int64(0)
+		for _, record := range records {
+			totalBytes += int64(len(record.Data))
+		}
+		atomic.AddInt64(&k.bytesInMemoryCount, totalBytes)
+		
 		// Track records for cleanup in case of early return
 		recordsToCleanup := int64(len(records))
+		bytesToCleanup := totalBytes
 		defer func() {
 			// Decrement any records that weren't successfully processed
 			if recordsToCleanup > 0 {
 				atomic.AddInt64(&k.recordsInMemoryCount, -recordsToCleanup)
+			}
+			if bytesToCleanup > 0 {
+				atomic.AddInt64(&k.bytesInMemoryCount, -bytesToCleanup)
 			}
 		}()
 		
 		if len(records) > 0 {
 			retrievedAt := time.Now()
 			for _, record := range records {
-			RecordLoop:
 				// Loop until we stop or the record is consumed, checkpointing if necessary.
+				recordPayloadBytes := int64(len(record.Data))
+			RecordLoop:
 				for {
 					select {
 					case <-commitTicker.C:
@@ -272,8 +284,10 @@ mainloop:
 						record:       &record,
 						checkpointer: checkpointer,
 						retrievedAt:  retrievedAt,
+						payloadBytes: recordPayloadBytes,
 					}:
 						recordsToCleanup-- // Record successfully sent to channel
+						bytesToCleanup -= recordPayloadBytes // Decrement bytes for successfully sent record
 						checkpointer.lastRecordPassed = time.Now() // Mark the time so we don't retain shards when we're too slow to do so
 						lastSeqToCheckp = aws.ToString(record.SequenceNumber)
 						break RecordLoop

--- a/shard_consumer_test.go
+++ b/shard_consumer_test.go
@@ -344,10 +344,26 @@ func TestPotentialLegitimateDuplicates(t *testing.T) {
 // duplicates in TestSplit were down to some incorrect handling of merging shards. This proved not to be the case, and the unit tests below further isolate the cause
 // for that phenomenon, but there's no harm in keeping this test to isolate the behaviour of consumers when shards merge.
 func TestShardsMerged(t *testing.T) {
+	testCases := []struct {
+		name         string
+		iteratorType types.ShardIteratorType
+	}{
+		{"TRIM_HORIZON", types.ShardIteratorTypeTrimHorizon},
+		{"LATEST", types.ShardIteratorTypeLatest},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			runShardsMergedTest(t, tc.iteratorType)
+		})
+	}
+}
+
+func runShardsMergedTest(t *testing.T, iteratorType types.ShardIteratorType) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
-	streamName := "TestShardsMerged_stream"
+	streamName := "TestShardsMerged_stream" + string(iteratorType)
 
 	k, dynamo := kinesisAndDynamoInstances(t)
 
@@ -365,7 +381,7 @@ func TestShardsMerged(t *testing.T) {
 		WithShardCheckFrequency(500 * time.Millisecond).
 		WithLeaderActionFrequency(500 * time.Millisecond).
 		WithCommitFrequency(100 * time.Millisecond).
-		WithIteratorType(types.ShardIteratorTypeLatest)
+		WithIteratorType(iteratorType)
 
 	kinsumer1, err := NewWithInterfaces(k, dynamo, streamName, *applicationName, "client_1", "", config)
 	require.NoError(t, err)

--- a/shard_consumer_test.go
+++ b/shard_consumer_test.go
@@ -365,7 +365,7 @@ func TestShardsMerged(t *testing.T) {
 		WithShardCheckFrequency(500 * time.Millisecond).
 		WithLeaderActionFrequency(500 * time.Millisecond).
 		WithCommitFrequency(100 * time.Millisecond).
-		WithIteratorType(types.ShardIteratorTypeTrimHorizon)
+		WithIteratorType(types.ShardIteratorTypeLatest)
 
 	kinsumer1, err := NewWithInterfaces(k, dynamo, streamName, *applicationName, "client_1", "", config)
 	require.NoError(t, err)
@@ -1200,14 +1200,14 @@ func TestMaxConcurrentShardsUnlimited(t *testing.T) {
 // TestProcessRecordsBatchSemaphoreAllPaths is a focused unit test that directly tests
 // the semaphore behavior in processRecordsBatch() for all possible code paths
 func TestProcessRecordsBatchSemaphoreAllPaths(t *testing.T) {
-	
+
 	// Configuration for checkpointer setup
 	type checkpointerConfig struct {
 		tableName           string
 		finished            bool
 		finalSequenceNumber string
 	}
-	
+
 	// Helper to inspect semaphore state directly
 	getSemaphoreUsed := func(sem chan struct{}) int {
 		if sem == nil {
@@ -1215,7 +1215,7 @@ func TestProcessRecordsBatchSemaphoreAllPaths(t *testing.T) {
 		}
 		return len(sem)
 	}
-	
+
 	// Helper to create kinsumer with test-specific configuration
 	createTestKinsumer := func(semaphore chan struct{}, stopChan chan struct{}, recordsChan chan *consumedRecord) *Kinsumer {
 		return &Kinsumer{
@@ -1227,11 +1227,11 @@ func TestProcessRecordsBatchSemaphoreAllPaths(t *testing.T) {
 			stop:           stopChan,
 		}
 	}
-	
+
 	// Helper to create checkpointer and ticker with test-specific configuration
 	createCheckpointerAndTicker := func(config checkpointerConfig, tickerInterval time.Duration) (*checkpointer, *time.Ticker) {
 		mockDynamo := mocks.NewMockDynamo([]string{"test-table"})
-		
+
 		checkpointer := &checkpointer{
 			sequenceNumber:      "",
 			shardID:             "test-shard",
@@ -1244,30 +1244,30 @@ func TestProcessRecordsBatchSemaphoreAllPaths(t *testing.T) {
 			finished:            config.finished,
 			finalSequenceNumber: config.finalSequenceNumber,
 		}
-		
+
 		ticker := time.NewTicker(tickerInterval)
-		
+
 		return checkpointer, ticker
 	}
-	
+
 	// Test cases covering all processRecordsBatch code paths
 	testCases := []struct {
-		name                 string
-		setupMock            func(*mocks.MockKinesis)
-		expectError          bool
-		description          string
-		stopChan             chan struct{}
-		recordsChan          chan *consumedRecord
-		tickerInterval       time.Duration
-		checkpointerConfig   checkpointerConfig
-		runStopGoroutine     bool
+		name               string
+		setupMock          func(*mocks.MockKinesis)
+		expectError        bool
+		description        string
+		stopChan           chan struct{}
+		recordsChan        chan *consumedRecord
+		tickerInterval     time.Duration
+		checkpointerConfig checkpointerConfig
+		runStopGoroutine   bool
 	}{
 		{
 			name:               "normal_success",
 			setupMock:          func(mk *mocks.MockKinesis) {}, // Default behavior - returns records
 			expectError:        false,
 			description:        "Normal processing should acquire and release semaphore",
-			stopChan:           nil, // No stop channel needed
+			stopChan:           nil,                             // No stop channel needed
 			recordsChan:        make(chan *consumedRecord, 100), // Buffered - won't block
 			tickerInterval:     100 * time.Millisecond,
 			checkpointerConfig: checkpointerConfig{tableName: "test-table", finished: false, finalSequenceNumber: ""},
@@ -1280,7 +1280,7 @@ func TestProcessRecordsBatchSemaphoreAllPaths(t *testing.T) {
 			},
 			expectError:        true,
 			description:        "GetRecords error should still release semaphore via defer",
-			stopChan:           nil, // No stop channel needed
+			stopChan:           nil,                             // No stop channel needed
 			recordsChan:        make(chan *consumedRecord, 100), // Buffered - won't block
 			tickerInterval:     100 * time.Millisecond,
 			checkpointerConfig: checkpointerConfig{tableName: "test-table", finished: false, finalSequenceNumber: ""},
@@ -1293,7 +1293,7 @@ func TestProcessRecordsBatchSemaphoreAllPaths(t *testing.T) {
 			},
 			expectError:        false,
 			description:        "No records returned should still release semaphore",
-			stopChan:           nil, // No stop channel needed
+			stopChan:           nil,                             // No stop channel needed
 			recordsChan:        make(chan *consumedRecord, 100), // Buffered - won't block
 			tickerInterval:     100 * time.Millisecond,
 			checkpointerConfig: checkpointerConfig{tableName: "test-table", finished: false, finalSequenceNumber: ""},
@@ -1306,7 +1306,7 @@ func TestProcessRecordsBatchSemaphoreAllPaths(t *testing.T) {
 			},
 			expectError:        false, // batchContinue, not error
 			description:        "ExpiredIteratorException with successful getShardIterator should release semaphore",
-			stopChan:           nil, // No stop channel needed
+			stopChan:           nil,                             // No stop channel needed
 			recordsChan:        make(chan *consumedRecord, 100), // Buffered - won't block
 			tickerInterval:     100 * time.Millisecond,
 			checkpointerConfig: checkpointerConfig{tableName: "test-table", finished: false, finalSequenceNumber: ""},
@@ -1319,7 +1319,7 @@ func TestProcessRecordsBatchSemaphoreAllPaths(t *testing.T) {
 			},
 			expectError:        true, // batchError when getShardIterator fails
 			description:        "ExpiredIteratorException with failed getShardIterator should release semaphore",
-			stopChan:           nil, // No stop channel needed
+			stopChan:           nil,                             // No stop channel needed
 			recordsChan:        make(chan *consumedRecord, 100), // Buffered - won't block
 			tickerInterval:     100 * time.Millisecond,
 			checkpointerConfig: checkpointerConfig{tableName: "test-table", finished: false, finalSequenceNumber: ""},
@@ -1332,7 +1332,7 @@ func TestProcessRecordsBatchSemaphoreAllPaths(t *testing.T) {
 			},
 			expectError:        false, // batchBreak, not error
 			description:        "Stop signal during record processing should release semaphore",
-			stopChan:           make(chan struct{}), // Need stop channel
+			stopChan:           make(chan struct{}),             // Need stop channel
 			recordsChan:        make(chan *consumedRecord, 100), // Buffered - won't block
 			tickerInterval:     100 * time.Millisecond,
 			checkpointerConfig: checkpointerConfig{tableName: "test-table", finished: false, finalSequenceNumber: ""},
@@ -1345,9 +1345,9 @@ func TestProcessRecordsBatchSemaphoreAllPaths(t *testing.T) {
 			},
 			expectError:        true, // batchError when commit fails
 			description:        "Commit ticker fires and commit fails should release semaphore",
-			stopChan:           nil, // No stop channel needed
-			recordsChan:        make(chan *consumedRecord), // Unbuffered - will block record sending to force commit ticker
-			tickerInterval:     1 * time.Millisecond, // Fast ticker
+			stopChan:           nil,                                                                                      // No stop channel needed
+			recordsChan:        make(chan *consumedRecord),                                                               // Unbuffered - will block record sending to force commit ticker
+			tickerInterval:     1 * time.Millisecond,                                                                     // Fast ticker
 			checkpointerConfig: checkpointerConfig{tableName: "error-trigger", finished: false, finalSequenceNumber: ""}, // Trigger error
 			runStopGoroutine:   false,
 		},
@@ -1358,38 +1358,38 @@ func TestProcessRecordsBatchSemaphoreAllPaths(t *testing.T) {
 			},
 			expectError:        false, // batchSuccess when commit succeeds with finishCommitted=true
 			description:        "Commit ticker fires and commit succeeds with finishCommitted should release semaphore",
-			stopChan:           nil, // No stop channel needed
-			recordsChan:        make(chan *consumedRecord), // Unbuffered - will block record sending to force commit ticker
-			tickerInterval:     1 * time.Millisecond, // Fast ticker
+			stopChan:           nil,                                                                                  // No stop channel needed
+			recordsChan:        make(chan *consumedRecord),                                                           // Unbuffered - will block record sending to force commit ticker
+			tickerInterval:     1 * time.Millisecond,                                                                 // Fast ticker
 			checkpointerConfig: checkpointerConfig{tableName: "test-table", finished: true, finalSequenceNumber: ""}, // Force finishCommitted=true
 			runStopGoroutine:   false,
 		},
 	}
-	
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Minimal setup - only what processRecordsBatch needs
 			semaphore := make(chan struct{}, 1) // Capacity of 1 for easy verification
 			mockKinesis := mocks.NewMockKinesis([]string{"test-shard"})
-			
+
 			// Apply test-specific mock setup
 			tc.setupMock(mockKinesis)
-			
+
 			// Create kinsumer with test-specific configuration
 			kinsumer := createTestKinsumer(semaphore, tc.stopChan, tc.recordsChan)
 			kinsumer.kinesis = mockKinesis // Set the mock kinesis
-			
+
 			// Create checkpointer and ticker with test-specific configuration
 			mockCheckpointer, ticker := createCheckpointerAndTicker(tc.checkpointerConfig, tc.tickerInterval)
 			defer ticker.Stop()
-			
+
 			lastSeq := ""
 			lastSeqNum := ""
-			
+
 			// Verify semaphore starts empty
 			before := getSemaphoreUsed(semaphore)
 			assert.Equal(t, 0, before, "Semaphore should start empty")
-			
+
 			// For stop signal test, close the stop channel after a delay to trigger batchBreak
 			if tc.runStopGoroutine && tc.stopChan != nil {
 				go func() {
@@ -1397,15 +1397,15 @@ func TestProcessRecordsBatchSemaphoreAllPaths(t *testing.T) {
 					close(tc.stopChan)
 				}()
 			}
-			
+
 			// Call processRecordsBatch directly - this is where semaphore logic lives
 			iterator := "iter-test-shard-0" // Use format that MockKinesis expects
 			_, result, err := kinsumer.processRecordsBatch(iterator, "test-shard", mockCheckpointer, &lastSeq, &lastSeqNum, ticker)
-			
+
 			// Verify semaphore is released regardless of success or error
 			after := getSemaphoreUsed(semaphore)
 			assert.Equal(t, 0, after, "Semaphore should be released for case: %s - %s", tc.name, tc.description)
-			
+
 			// Verify expected error behavior
 			if tc.expectError {
 				assert.Equal(t, batchError, result, "Expected batchError result for %s", tc.name)
@@ -1414,13 +1414,12 @@ func TestProcessRecordsBatchSemaphoreAllPaths(t *testing.T) {
 				assert.NoError(t, err, "Expected no error for %s", tc.name)
 				assert.NotEqual(t, batchError, result, "Expected non-error result for %s", tc.name)
 			}
-			
+
 			// Verify MockKinesis saw exactly one call
 			totalCalls := mockKinesis.GetTotalCalls()
 			assert.Equal(t, 1, totalCalls, "Expected exactly 1 GetRecords call for %s", tc.name)
-			
+
 			t.Logf("✓ %s: Semaphore properly released (before=%d, after=%d)", tc.description, before, after)
 		})
 	}
 }
-

--- a/shard_consumer_test.go
+++ b/shard_consumer_test.go
@@ -465,7 +465,7 @@ func runShardsMergedTest(t *testing.T, iteratorType types.ShardIteratorType) {
 				}
 				cachedShardIDs := shardCache.ShardIDs
 
-				curShardIDs, err := loadShardIDsFromKinesis(k, streamName)
+				curShardIDs, _, _, err := loadShardIDsFromKinesis(k, streamName)
 				if err != nil {
 					fmt.Printf("error loading shard IDs from kinesis: %v", err)
 				}

--- a/shard_consumer_test.go
+++ b/shard_consumer_test.go
@@ -8,8 +8,11 @@ import (
 	"time"
 
 	"github.com/twitchscience/kinsumer/kinsumeriface"
+	"github.com/twitchscience/kinsumer/mocks"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	dbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis/types"
 
@@ -1028,3 +1031,396 @@ func TestGetDupesFromSlice(t *testing.T) {
 	dupes2 := getDupesFromSlice(sliceWithoutDupes)
 	assert.Equal(t, 0, len(dupes2))
 }
+
+// TestMaxConcurrentShards tests the maxConcurrentShards feature using MockKinesis
+// to verify that semaphore properly limits concurrent shard record fetching
+func TestMaxConcurrentShards(t *testing.T) {
+
+	// Test setup: Create 5 mock shards with concurrency limit of 2
+	shardIDs := []string{"shard-001", "shard-002", "shard-003", "shard-004", "shard-005"}
+	mockKinesis := mocks.NewMockKinesis(shardIDs)
+
+	// Create MockDynamo with proper table names (applicationName + "_" + table_type)
+	mockDynamo := mocks.NewMockDynamo([]string{"test-app_checkpoints", "test-app_clients", "test-app_metadata"})
+
+	// Pre-populate checkpoint records for each shard (unowned so they can be captured)
+	for _, shardID := range shardIDs {
+		checkpointItem := map[string]dbtypes.AttributeValue{
+			"Shard":          &dbtypes.AttributeValueMemberS{Value: shardID},
+			"SequenceNumber": &dbtypes.AttributeValueMemberS{Value: ""},  // Start from beginning
+			"LastUpdate":     &dbtypes.AttributeValueMemberN{Value: "0"}, // Old timestamp = unowned
+			// OwnerName and OwnerID are nil (unowned)
+			// Finished is nil (active shard)
+		}
+		_, err := mockDynamo.PutItem(t.Context(), &dynamodb.PutItemInput{
+			TableName: aws.String("test-app_checkpoints"),
+			Item:      checkpointItem,
+		})
+		require.NoError(t, err, "Failed to populate checkpoint for shard %s", shardID)
+	}
+
+	// Set a delay to make concurrent behavior observable
+	mockKinesis.SetDelay(100 * time.Millisecond)
+
+	// Test with concurrency limit
+	config := NewConfig().
+		WithBufferSize(1000).
+		WithShardCheckFrequency(500 * time.Millisecond).
+		WithLeaderActionFrequency(500 * time.Millisecond).
+		WithCommitFrequency(100 * time.Millisecond).
+		WithMaxConcurrentShards(2) // Limit to 2 concurrent shards
+
+	kinsumer, err := NewWithInterfaces(mockKinesis, mockDynamo, "test-stream", "test-app", "test-client", "", config)
+	require.NoError(t, err, "Failed to create kinsumer with concurrency limit")
+
+	// Initialize channels that consume() expects to exist
+	kinsumer.stop = make(chan struct{})
+	kinsumer.shardErrors = make(chan shardConsumerError, 10)
+	kinsumer.records = make(chan *consumedRecord, 1000)
+
+	// Manually start consuming each shard
+	var wg sync.WaitGroup
+	for _, shardID := range shardIDs {
+		wg.Add(1)
+		go func(shard string) {
+			defer wg.Done()
+			kinsumer.waitGroup.Add(1) // consume() expects this
+			kinsumer.consume(shard)
+		}(shardID)
+	}
+
+	// Wait a moment for consumers to start up and begin processing
+	time.Sleep(50 * time.Millisecond)
+
+	// Verify that we reach the expected concurrency level (2)
+	success := mockKinesis.WaitForConcurrentCalls(2, 2*time.Second)
+	assert.True(t, success, "Expected to reach 2 concurrent calls")
+
+	// Let it run for a bit to collect data
+	time.Sleep(500 * time.Millisecond)
+
+	// Verify concurrency never exceeded the limit
+	maxConcurrent := mockKinesis.GetMaxConcurrentCalls()
+	assert.LessOrEqual(t, maxConcurrent, 2, "Concurrent calls should never exceed limit of 2, got %d", maxConcurrent)
+
+	// Verify we got some calls (processing is happening)
+	totalCalls := mockKinesis.GetTotalCalls()
+	assert.Greater(t, totalCalls, 5, "Should have made multiple GetRecords calls, got %d", totalCalls)
+
+	// Stop consumers
+	close(kinsumer.stop)
+
+	// Wait for all goroutines to finish
+	wg.Wait()
+
+	t.Logf("Max concurrent calls observed: %d (limit was 2)", maxConcurrent)
+	t.Logf("Total GetRecords calls made: %d", totalCalls)
+}
+
+// TestMaxConcurrentShardsUnlimited tests that maxConcurrentShards=0 means unlimited
+func TestMaxConcurrentShardsUnlimited(t *testing.T) {
+
+	// Test setup: Create 5 mock shards with no concurrency limit
+	shardIDs := []string{"shard-001", "shard-002", "shard-003", "shard-004", "shard-005"}
+	mockKinesis := mocks.NewMockKinesis(shardIDs)
+
+	// Create MockDynamo with proper table names (applicationName + "_" + table_type)
+	mockDynamo := mocks.NewMockDynamo([]string{"test-app_checkpoints", "test-app_clients", "test-app_metadata"})
+
+	// Pre-populate checkpoint records for each shard (unowned so they can be captured)
+	for _, shardID := range shardIDs {
+		checkpointItem := map[string]dbtypes.AttributeValue{
+			"Shard":          &dbtypes.AttributeValueMemberS{Value: shardID},
+			"SequenceNumber": &dbtypes.AttributeValueMemberS{Value: ""},  // Start from beginning
+			"LastUpdate":     &dbtypes.AttributeValueMemberN{Value: "0"}, // Old timestamp = unowned
+			// OwnerName and OwnerID are nil (unowned)
+			// Finished is nil (active shard)
+		}
+		_, err := mockDynamo.PutItem(t.Context(), &dynamodb.PutItemInput{
+			TableName: aws.String("test-app_checkpoints"),
+			Item:      checkpointItem,
+		})
+		require.NoError(t, err, "Failed to populate checkpoint for shard %s", shardID)
+	}
+
+	// Set a delay to make concurrent behavior observable
+	mockKinesis.SetDelay(100 * time.Millisecond)
+
+	// Test with unlimited concurrency (default)
+	config := NewConfig().
+		WithBufferSize(1000).
+		WithShardCheckFrequency(500 * time.Millisecond).
+		WithLeaderActionFrequency(500 * time.Millisecond).
+		WithCommitFrequency(100 * time.Millisecond)
+		// maxConcurrentShards defaults to 0 (unlimited)
+
+	kinsumer, err := NewWithInterfaces(mockKinesis, mockDynamo, "test-stream", "test-app", "test-client", "", config)
+	require.NoError(t, err, "Failed to create kinsumer without concurrency limit")
+
+	// Initialize channels that consume() expects to exist
+	kinsumer.stop = make(chan struct{})
+	kinsumer.shardErrors = make(chan shardConsumerError, 10)
+	kinsumer.records = make(chan *consumedRecord, 1000)
+
+	// Manually start consuming each shard
+	var wg sync.WaitGroup
+	for _, shardID := range shardIDs {
+		wg.Add(1)
+		go func(shard string) {
+			defer wg.Done()
+			kinsumer.waitGroup.Add(1) // consume() expects this
+			kinsumer.consume(shard)
+		}(shardID)
+	}
+
+	// Wait a moment for consumers to start up
+	time.Sleep(50 * time.Millisecond)
+
+	// With unlimited concurrency, we should be able to reach all 5 concurrent calls
+	success := mockKinesis.WaitForConcurrentCalls(5, 2*time.Second)
+	assert.True(t, success, "Expected to reach 5 concurrent calls with unlimited setting")
+
+	// Let it run for a bit
+	time.Sleep(300 * time.Millisecond)
+
+	// Verify we can process all shards concurrently
+	maxConcurrent := mockKinesis.GetMaxConcurrentCalls()
+	assert.Equal(t, 5, maxConcurrent, "Should allow all 5 shards to process concurrently, got %d", maxConcurrent)
+
+	// Stop consumers
+	close(kinsumer.stop)
+
+	// Wait for all goroutines to finish
+	wg.Wait()
+
+	t.Logf("Max concurrent calls observed: %d (should be 5 with unlimited)", maxConcurrent)
+	t.Logf("Total GetRecords calls made: %d", mockKinesis.GetTotalCalls())
+}
+
+// TestProcessRecordsBatchSemaphoreAllPaths is a focused unit test that directly tests
+// the semaphore behavior in processRecordsBatch() for all possible code paths
+func TestProcessRecordsBatchSemaphoreAllPaths(t *testing.T) {
+	
+	// Configuration for checkpointer setup
+	type checkpointerConfig struct {
+		tableName           string
+		finished            bool
+		finalSequenceNumber string
+	}
+	
+	// Helper to inspect semaphore state directly
+	getSemaphoreUsed := func(sem chan struct{}) int {
+		if sem == nil {
+			return 0
+		}
+		return len(sem)
+	}
+	
+	// Helper to create kinsumer with test-specific configuration
+	createTestKinsumer := func(semaphore chan struct{}, stopChan chan struct{}, recordsChan chan *consumedRecord) *Kinsumer {
+		return &Kinsumer{
+			kinesis:        nil, // Will be set by caller
+			shardSemaphore: semaphore,
+			records:        recordsChan,
+			config:         NewConfig().WithMaxConcurrentShards(1),
+			metricsManager: newMetricsManager(&DefaultLogger{}),
+			stop:           stopChan,
+		}
+	}
+	
+	// Helper to create checkpointer and ticker with test-specific configuration
+	createCheckpointerAndTicker := func(config checkpointerConfig, tickerInterval time.Duration) (*checkpointer, *time.Ticker) {
+		mockDynamo := mocks.NewMockDynamo([]string{"test-table"})
+		
+		checkpointer := &checkpointer{
+			sequenceNumber:      "",
+			shardID:             "test-shard",
+			tableName:           config.tableName,
+			dynamodb:            mockDynamo,
+			ownerName:           "test-owner",
+			ownerID:             "test-owner-id",
+			stats:               &NoopStatReceiver{},
+			lastUpdate:          time.Now().UnixNano(),
+			finished:            config.finished,
+			finalSequenceNumber: config.finalSequenceNumber,
+		}
+		
+		ticker := time.NewTicker(tickerInterval)
+		
+		return checkpointer, ticker
+	}
+	
+	// Test cases covering all processRecordsBatch code paths
+	testCases := []struct {
+		name                 string
+		setupMock            func(*mocks.MockKinesis)
+		expectError          bool
+		description          string
+		stopChan             chan struct{}
+		recordsChan          chan *consumedRecord
+		tickerInterval       time.Duration
+		checkpointerConfig   checkpointerConfig
+		runStopGoroutine     bool
+	}{
+		{
+			name:               "normal_success",
+			setupMock:          func(mk *mocks.MockKinesis) {}, // Default behavior - returns records
+			expectError:        false,
+			description:        "Normal processing should acquire and release semaphore",
+			stopChan:           nil, // No stop channel needed
+			recordsChan:        make(chan *consumedRecord, 100), // Buffered - won't block
+			tickerInterval:     100 * time.Millisecond,
+			checkpointerConfig: checkpointerConfig{tableName: "test-table", finished: false, finalSequenceNumber: ""},
+			runStopGoroutine:   false,
+		},
+		{
+			name: "getRecords_error",
+			setupMock: func(mk *mocks.MockKinesis) {
+				mk.SetGenericError("test-shard") // Will return generic error (not ExpiredIteratorException)
+			},
+			expectError:        true,
+			description:        "GetRecords error should still release semaphore via defer",
+			stopChan:           nil, // No stop channel needed
+			recordsChan:        make(chan *consumedRecord, 100), // Buffered - won't block
+			tickerInterval:     100 * time.Millisecond,
+			checkpointerConfig: checkpointerConfig{tableName: "test-table", finished: false, finalSequenceNumber: ""},
+			runStopGoroutine:   false,
+		},
+		{
+			name: "no_records_returned",
+			setupMock: func(mk *mocks.MockKinesis) {
+				mk.SetEmptyRecords("test-shard") // Return empty records array
+			},
+			expectError:        false,
+			description:        "No records returned should still release semaphore",
+			stopChan:           nil, // No stop channel needed
+			recordsChan:        make(chan *consumedRecord, 100), // Buffered - won't block
+			tickerInterval:     100 * time.Millisecond,
+			checkpointerConfig: checkpointerConfig{tableName: "test-table", finished: false, finalSequenceNumber: ""},
+			runStopGoroutine:   false,
+		},
+		{
+			name: "expired_iterator_getShardIterator_succeeds",
+			setupMock: func(mk *mocks.MockKinesis) {
+				mk.SetError("test-shard", true) // Return ExpiredIteratorException, but GetShardIterator will succeed
+			},
+			expectError:        false, // batchContinue, not error
+			description:        "ExpiredIteratorException with successful getShardIterator should release semaphore",
+			stopChan:           nil, // No stop channel needed
+			recordsChan:        make(chan *consumedRecord, 100), // Buffered - won't block
+			tickerInterval:     100 * time.Millisecond,
+			checkpointerConfig: checkpointerConfig{tableName: "test-table", finished: false, finalSequenceNumber: ""},
+			runStopGoroutine:   false,
+		},
+		{
+			name: "expired_iterator_getShardIterator_fails",
+			setupMock: func(mk *mocks.MockKinesis) {
+				mk.SetBothGetRecordsAndGetShardIteratorErrors("test-shard") // Both GetRecords and GetShardIterator fail
+			},
+			expectError:        true, // batchError when getShardIterator fails
+			description:        "ExpiredIteratorException with failed getShardIterator should release semaphore",
+			stopChan:           nil, // No stop channel needed
+			recordsChan:        make(chan *consumedRecord, 100), // Buffered - won't block
+			tickerInterval:     100 * time.Millisecond,
+			checkpointerConfig: checkpointerConfig{tableName: "test-table", finished: false, finalSequenceNumber: ""},
+			runStopGoroutine:   false,
+		},
+		{
+			name: "stop_signal_received",
+			setupMock: func(mk *mocks.MockKinesis) {
+				// Keep default behavior - return records so we enter the RecordLoop
+			},
+			expectError:        false, // batchBreak, not error
+			description:        "Stop signal during record processing should release semaphore",
+			stopChan:           make(chan struct{}), // Need stop channel
+			recordsChan:        make(chan *consumedRecord, 100), // Buffered - won't block
+			tickerInterval:     100 * time.Millisecond,
+			checkpointerConfig: checkpointerConfig{tableName: "test-table", finished: false, finalSequenceNumber: ""},
+			runStopGoroutine:   true,
+		},
+		{
+			name: "commit_ticker_fires_commit_fails",
+			setupMock: func(mk *mocks.MockKinesis) {
+				// Keep default behavior - return records so we enter the RecordLoop
+			},
+			expectError:        true, // batchError when commit fails
+			description:        "Commit ticker fires and commit fails should release semaphore",
+			stopChan:           nil, // No stop channel needed
+			recordsChan:        make(chan *consumedRecord), // Unbuffered - will block record sending to force commit ticker
+			tickerInterval:     1 * time.Millisecond, // Fast ticker
+			checkpointerConfig: checkpointerConfig{tableName: "error-trigger", finished: false, finalSequenceNumber: ""}, // Trigger error
+			runStopGoroutine:   false,
+		},
+		{
+			name: "commit_ticker_fires_commit_succeeds_finished",
+			setupMock: func(mk *mocks.MockKinesis) {
+				// Keep default behavior - return records so we enter the RecordLoop
+			},
+			expectError:        false, // batchSuccess when commit succeeds with finishCommitted=true
+			description:        "Commit ticker fires and commit succeeds with finishCommitted should release semaphore",
+			stopChan:           nil, // No stop channel needed
+			recordsChan:        make(chan *consumedRecord), // Unbuffered - will block record sending to force commit ticker
+			tickerInterval:     1 * time.Millisecond, // Fast ticker
+			checkpointerConfig: checkpointerConfig{tableName: "test-table", finished: true, finalSequenceNumber: ""}, // Force finishCommitted=true
+			runStopGoroutine:   false,
+		},
+	}
+	
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Minimal setup - only what processRecordsBatch needs
+			semaphore := make(chan struct{}, 1) // Capacity of 1 for easy verification
+			mockKinesis := mocks.NewMockKinesis([]string{"test-shard"})
+			
+			// Apply test-specific mock setup
+			tc.setupMock(mockKinesis)
+			
+			// Create kinsumer with test-specific configuration
+			kinsumer := createTestKinsumer(semaphore, tc.stopChan, tc.recordsChan)
+			kinsumer.kinesis = mockKinesis // Set the mock kinesis
+			
+			// Create checkpointer and ticker with test-specific configuration
+			mockCheckpointer, ticker := createCheckpointerAndTicker(tc.checkpointerConfig, tc.tickerInterval)
+			defer ticker.Stop()
+			
+			lastSeq := ""
+			lastSeqNum := ""
+			
+			// Verify semaphore starts empty
+			before := getSemaphoreUsed(semaphore)
+			assert.Equal(t, 0, before, "Semaphore should start empty")
+			
+			// For stop signal test, close the stop channel after a delay to trigger batchBreak
+			if tc.runStopGoroutine && tc.stopChan != nil {
+				go func() {
+					time.Sleep(10 * time.Millisecond) // Small delay to let processing start
+					close(tc.stopChan)
+				}()
+			}
+			
+			// Call processRecordsBatch directly - this is where semaphore logic lives
+			iterator := "iter-test-shard-0" // Use format that MockKinesis expects
+			_, result, err := kinsumer.processRecordsBatch(iterator, "test-shard", mockCheckpointer, &lastSeq, &lastSeqNum, ticker)
+			
+			// Verify semaphore is released regardless of success or error
+			after := getSemaphoreUsed(semaphore)
+			assert.Equal(t, 0, after, "Semaphore should be released for case: %s - %s", tc.name, tc.description)
+			
+			// Verify expected error behavior
+			if tc.expectError {
+				assert.Equal(t, batchError, result, "Expected batchError result for %s", tc.name)
+				assert.Error(t, err, "Expected error for %s", tc.name)
+			} else {
+				assert.NoError(t, err, "Expected no error for %s", tc.name)
+				assert.NotEqual(t, batchError, result, "Expected non-error result for %s", tc.name)
+			}
+			
+			// Verify MockKinesis saw exactly one call
+			totalCalls := mockKinesis.GetTotalCalls()
+			assert.Equal(t, 1, totalCalls, "Expected exactly 1 GetRecords call for %s", tc.name)
+			
+			t.Logf("✓ %s: Semaphore properly released (before=%d, after=%d)", tc.description, before, after)
+		})
+	}
+}
+

--- a/shard_consumer_test.go
+++ b/shard_consumer_test.go
@@ -2,11 +2,12 @@ package kinsumer
 
 import (
 	"fmt"
-	"github.com/twitchscience/kinsumer/kinsumeriface"
 	"strconv"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/twitchscience/kinsumer/kinsumeriface"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis"
@@ -33,10 +34,13 @@ func TestShardConsumer(t *testing.T) {
 	err := setupTestEnvironment(t, k, dynamo, streamName, 1)
 	require.NoError(t, err, "Problems setting up the test environment")
 
-	config := NewConfig().WithBufferSize(1000)
-	config = config.WithShardCheckFrequency(500 * time.Millisecond)
-	config = config.WithLeaderActionFrequency(500 * time.Millisecond)
+	config := NewConfig().
+		WithBufferSize(1000).
+		WithShardCheckFrequency(500 * time.Millisecond).
+		WithLeaderActionFrequency(500 * time.Millisecond).
+		WithIteratorType(types.ShardIteratorTypeTrimHorizon)
 	kinsumer1, err := NewWithInterfaces(k, dynamo, streamName, *applicationName, "client_1", "", config)
+	require.NoError(t, err)
 
 	desc, err := k.DescribeStream(t.Context(), &kinesis.DescribeStreamInput{
 		StreamName: &streamName,
@@ -74,10 +78,12 @@ func TestForcefulOwnershipChange(t *testing.T) {
 	require.NoError(t, err, "Problems setting up the test environment")
 
 	// Create two kinsumer instances, but don't call run
-	config := NewConfig().WithBufferSize(1000)
-	config = config.WithShardCheckFrequency(500 * time.Millisecond)
-	config = config.WithLeaderActionFrequency(500 * time.Millisecond)
-	config = config.WithCommitFrequency(100 * time.Millisecond)
+	config := NewConfig().
+		WithBufferSize(1000).
+		WithShardCheckFrequency(500 * time.Millisecond).
+		WithLeaderActionFrequency(500 * time.Millisecond).
+		WithCommitFrequency(100 * time.Millisecond).
+		WithIteratorType(types.ShardIteratorTypeTrimHorizon)
 
 	// Set vastly different max ages to synthetically create a forced ownership change
 	maxAge1 := 10 * time.Second
@@ -216,10 +222,12 @@ func TestPotentialLegitimateDuplicates(t *testing.T) {
 	require.NoError(t, err, "Problems setting up the test environment")
 
 	// Create two kinsumer instances, but don't call run
-	config := NewConfig().WithBufferSize(1000)
-	config = config.WithShardCheckFrequency(500 * time.Millisecond)
-	config = config.WithLeaderActionFrequency(500 * time.Millisecond)
-	config = config.WithCommitFrequency(100 * time.Millisecond)
+	config := NewConfig().
+		WithBufferSize(1000).
+		WithShardCheckFrequency(500 * time.Millisecond).
+		WithLeaderActionFrequency(500 * time.Millisecond).
+		WithCommitFrequency(100 * time.Millisecond).
+		WithIteratorType(types.ShardIteratorTypeTrimHorizon)
 
 	// Set vastly different max ages to synthetically create a forced ownership change
 	maxAge1 := 10 * time.Second
@@ -229,7 +237,9 @@ func TestPotentialLegitimateDuplicates(t *testing.T) {
 	config2 := config.WithClientRecordMaxAge(&maxAge2)
 
 	kinsumer1, err := NewWithInterfaces(k, dynamo, streamName, *applicationName, "client_1", "", config1)
+	require.NoError(t, err)
 	kinsumer2, err := NewWithInterfaces(k, dynamo, streamName, *applicationName, "client_2", "", config2)
+	require.NoError(t, err)
 
 	desc, err := k.DescribeStream(t.Context(), &kinesis.DescribeStreamInput{
 		StreamName: &streamName,
@@ -347,14 +357,19 @@ func TestShardsMerged(t *testing.T) {
 	require.NoError(t, err, "Problems setting up the test environment")
 
 	// Create two kinsumer instances, but don't call run
-	config := NewConfig().WithBufferSize(1000)
-	config = config.WithShardCheckFrequency(500 * time.Millisecond)
-	config = config.WithLeaderActionFrequency(500 * time.Millisecond)
-	config = config.WithCommitFrequency(100 * time.Millisecond)
+	config := NewConfig().
+		WithBufferSize(1000).
+		WithShardCheckFrequency(500 * time.Millisecond).
+		WithLeaderActionFrequency(500 * time.Millisecond).
+		WithCommitFrequency(100 * time.Millisecond).
+		WithIteratorType(types.ShardIteratorTypeTrimHorizon)
 
 	kinsumer1, err := NewWithInterfaces(k, dynamo, streamName, *applicationName, "client_1", "", config)
+	require.NoError(t, err)
 	kinsumer2, err := NewWithInterfaces(k, dynamo, streamName, *applicationName, "client_2", "", config)
+	require.NoError(t, err)
 	kinsumer3, err := NewWithInterfaces(k, dynamo, streamName, *applicationName, "client_3", "", config)
+	require.NoError(t, err)
 
 	desc, err := k.DescribeStream(t.Context(), &kinesis.DescribeStreamInput{
 		StreamName: &streamName,
@@ -520,12 +535,15 @@ func TestConsumerStopStart(t *testing.T) {
 	require.NoError(t, err, "Problems setting up the test environment")
 
 	// Create two kinsumer instances, but don't call run
-	config := NewConfig().WithBufferSize(1000)
-	config = config.WithShardCheckFrequency(500 * time.Millisecond)
-	config = config.WithLeaderActionFrequency(500 * time.Millisecond)
-	config = config.WithCommitFrequency(50 * time.Millisecond)
+	config := NewConfig().
+		WithBufferSize(1000).
+		WithShardCheckFrequency(500 * time.Millisecond).
+		WithLeaderActionFrequency(500 * time.Millisecond).
+		WithCommitFrequency(50 * time.Millisecond).
+		WithIteratorType(types.ShardIteratorTypeTrimHorizon)
 
 	kinsumer, err := NewWithInterfaces(k, dynamo, streamName, *applicationName, "client_1", "", config)
+	require.NoError(t, err)
 
 	desc, err := k.DescribeStream(t.Context(), &kinesis.DescribeStreamInput{
 		StreamName: &streamName,
@@ -592,14 +610,19 @@ func TestMultipleConsumerStopStart(t *testing.T) {
 	require.NoError(t, err, "Problems setting up the test environment")
 
 	// Create two kinsumer instances, but don't call run
-	config := NewConfig().WithBufferSize(1000)
-	config = config.WithShardCheckFrequency(500 * time.Millisecond)
-	config = config.WithLeaderActionFrequency(500 * time.Millisecond)
-	config = config.WithCommitFrequency(50 * time.Millisecond)
+	config := NewConfig().
+		WithBufferSize(1000).
+		WithShardCheckFrequency(500 * time.Millisecond).
+		WithLeaderActionFrequency(500 * time.Millisecond).
+		WithCommitFrequency(50 * time.Millisecond).
+		WithIteratorType(types.ShardIteratorTypeTrimHorizon)
 
 	kinsumer1, err := NewWithInterfaces(k, dynamo, streamName, *applicationName, "client_1", "", config)
+	require.NoError(t, err)
 	kinsumer2, err := NewWithInterfaces(k, dynamo, streamName, *applicationName, "client_2", "", config)
+	require.NoError(t, err)
 	kinsumer3, err := NewWithInterfaces(k, dynamo, streamName, *applicationName, "client_3", "", config)
+	require.NoError(t, err)
 
 	desc, err := k.DescribeStream(t.Context(), &kinesis.DescribeStreamInput{
 		StreamName: &streamName,
@@ -715,12 +738,15 @@ func TestDelayedUpdateDuplicates(t *testing.T) {
 	require.NoError(t, err, "Problems setting up the test environment")
 
 	// Create two kinsumer instances, but don't call run
-	config := NewConfig().WithBufferSize(1000)
-	config = config.WithShardCheckFrequency(500 * time.Millisecond)
-	config = config.WithLeaderActionFrequency(500 * time.Millisecond)
-	config = config.WithCommitFrequency(50 * time.Millisecond)
+	config := NewConfig().
+		WithBufferSize(1000).
+		WithShardCheckFrequency(500 * time.Millisecond).
+		WithLeaderActionFrequency(500 * time.Millisecond).
+		WithCommitFrequency(50 * time.Millisecond).
+		WithIteratorType(types.ShardIteratorTypeTrimHorizon)
 
 	kinsumer, err := NewWithInterfaces(k, dynamo, streamName, *applicationName, "client_1", "", config)
+	require.NoError(t, err)
 
 	desc, err := k.DescribeStream(t.Context(), &kinesis.DescribeStreamInput{
 		StreamName: &streamName,

--- a/statreceiver.go
+++ b/statreceiver.go
@@ -27,4 +27,10 @@ type StatReceiver interface {
 	// `shardID` ID of the shard that the records were retrieved from
 	// `lag` How far the records are from the tip of the stream.
 	EventsFromKinesis(num int, shardID string, lag time.Duration)
+
+	// RecordsInMemory is called periodically to report the current number of records
+	// that have been pulled from Kinesis and are buffered in memory, waiting to be
+	// delivered to the client.
+	// `count` Current number of records in the internal buffer
+	RecordsInMemory(count int)
 }

--- a/statreceiver.go
+++ b/statreceiver.go
@@ -32,7 +32,7 @@ type StatReceiver interface {
 	// that have been pulled from Kinesis and are buffered in memory, waiting to be
 	// delivered to the client.
 	// `count` Current number of records in the internal buffer
-	RecordsInMemory(count int)
+	RecordsInMemory(count int64)
 
 	// RecordsInMemoryBytes is called periodically to report the current total bytes
 	// of record payloads that have been pulled from Kinesis and are buffered in memory,

--- a/statreceiver.go
+++ b/statreceiver.go
@@ -33,4 +33,10 @@ type StatReceiver interface {
 	// delivered to the client.
 	// `count` Current number of records in the internal buffer
 	RecordsInMemory(count int)
+
+	// RecordsInMemoryBytes is called periodically to report the current total bytes
+	// of record payloads that have been pulled from Kinesis and are buffered in memory,
+	// waiting to be delivered to the client.
+	// `bytes` Current total payload bytes in the internal buffer
+	RecordsInMemoryBytes(bytes int64)
 }

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -66,3 +66,9 @@ func (s *Statsd) EventsFromKinesis(num int, shardID string, lag time.Duration) {
 func (s *Statsd) RecordsInMemory(count int) {
 	_ = s.client.Gauge("kinsumer.records_in_memory", int64(count), 1.0)
 }
+
+// RecordsInMemoryBytes implementation that writes to statsd a gauge metric about
+// the current total payload bytes buffered in memory
+func (s *Statsd) RecordsInMemoryBytes(bytes int64) {
+	_ = s.client.Gauge("kinsumer.records_in_memory_bytes", bytes, 1.0)
+}

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -14,11 +14,13 @@ type Statsd struct {
 	client statsd.StatSender
 }
 
-// New creates a new Statsd statreceiver with a new instance of a cactus statter
+// New creates a new Statsd statreceiver with buffering enabled by default
 func New(addr, prefix string) (*Statsd, error) {
 	sd, err := statsd.NewClientWithConfig(&statsd.ClientConfig{
-		Address: addr,
-		Prefix:  prefix,
+		Address:       addr,
+		Prefix:        prefix,
+		UseBuffered:   true,                    // Enable buffering by default
+		FlushInterval: 1 * time.Second,        // Sensible default flush interval
 	})
 
 	if err != nil {

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -63,8 +63,8 @@ func (s *Statsd) EventsFromKinesis(num int, shardID string, lag time.Duration) {
 
 // RecordsInMemory implementation that writes to statsd a gauge metric about
 // the current number of records buffered in memory
-func (s *Statsd) RecordsInMemory(count int) {
-	_ = s.client.Gauge("kinsumer.records_in_memory", int64(count), 1.0)
+func (s *Statsd) RecordsInMemory(count int64) {
+	_ = s.client.Gauge("kinsumer.records_in_memory", count, 1.0)
 }
 
 // RecordsInMemoryBytes implementation that writes to statsd a gauge metric about

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -58,3 +58,9 @@ func (s *Statsd) EventsFromKinesis(num int, shardID string, lag time.Duration) {
 	_ = s.client.TimingDuration(fmt.Sprintf("kinsumer.%s.lag", shardID), lag, 1.0)
 	_ = s.client.Inc(fmt.Sprintf("kinsumer.%s.retrieved", shardID), int64(num), 1.0)
 }
+
+// RecordsInMemory implementation that writes to statsd a gauge metric about
+// the current number of records buffered in memory
+func (s *Statsd) RecordsInMemory(count int) {
+	_ = s.client.Gauge("kinsumer.records_in_memory", int64(count), 1.0)
+}


### PR DESCRIPTION
This PR fixes a critical issue with the implementation of configuring shard iterator type in release/1.7.0

## The problem:

Previously, we handled the configuration of iterator type in the shard consumer. What we didn't realise is that this simple implementation uses the configured iterator for _every_ new shard - even those that have been created during a scaling action.

So, any data for a new shard that arrived before we began consuming would be lost.

This problem is demonstrated in the test changes implemented in the first three commits - (TestSplit and TestShardsMerged). For iterator type TRIM_HORIZON they're fine, for LATEST they lose data where they shouldn't.

## The solution:

The original kinsumer implementation had a mechanism whereby we could use LATEST if we amend the DDB table to have a sequenceNumber of "LATEST". I reverted the consumer logic back to this mechanism, and then implemented a "bootstrap" mechnanism.

It works as follows:

- If no shards are registered (in the metadata table), and LATEST is configured, we need to bootstrap.
- We bootstrap by adding records to the checkpoints table for all shards found in kinesis
- If they're open, mark them with "LATEST", if they're closed mark them as finished (checkpoints table)
- If it looks like another client is updating checkpoints, wait till it stops (if it stops before completing all shards, take over)
- Once we have bootstrapped, register the shards (metadata table)

## Some details/considerations:

Clients use the metadata register to get the list of shards to allocate for consumption. This is normally managed by leader actions - those are paused until we register shards now.

Checkpoints are used by the leader to determine when a shard is finished, and by clients to determine where in a shard to start.

I attempted to use batch writes to avoid spamming DDB when there are a lot of shards - but conention cannot be avoided (even by putting all the logic in leader actions), so I reverted back to using single conditional writes, and added a mechanism to reduce the scope for contention
