### PR TITLE
Make metrics config cleaner

### DIFF
--- a/config.go
+++ b/config.go
@@ -151,7 +151,7 @@ func (c Config) WithBufferSize(bufferSize int) Config {
 	return c
 }
 
-// WithStats returns a Config with a modified stats
+// WithStats returns a Config with a modified stats receiver
 func (c Config) WithStats(stats StatReceiver) Config {
 	c.stats = stats
 	return c

--- a/kinsumer.go
+++ b/kinsumer.go
@@ -225,6 +225,12 @@ func NewWithInterfaces(
 		config.clientRecordMaxAge = &maxAge
 	}
 
+	// Wrap the stats receiver with filtering based on metrics configuration
+	// This happens after config validation to ensure we have the final configuration
+	if config.stats != nil {
+		config.stats = newFilteredStatReceiver(config.stats, config.metricsConfig)
+	}
+
 	consumer := &Kinsumer{
 		streamName:            streamName,
 		kinesis:               kinesis,

--- a/shard_consumer.go
+++ b/shard_consumer.go
@@ -16,6 +16,7 @@ import (
 )
 
 
+
 // getShardIterator gets a shard iterator after the last sequence number we read or at the start of the stream
 func getShardIterator(k kinsumeriface.KinesisAPI, streamName string, shardID string, sequenceNumber string, iteratorStartTimestamp *time.Time) (string, error) {
 	shardIteratorType := ktypes.ShardIteratorTypeAfterSequenceNumber

--- a/shard_consumer.go
+++ b/shard_consumer.go
@@ -6,16 +6,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/twitchscience/kinsumer/kinsumeriface"
 	"time"
+
+	"github.com/twitchscience/kinsumer/kinsumeriface"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis"
 	ktypes "github.com/aws/aws-sdk-go-v2/service/kinesis/types"
 	smithy "github.com/aws/smithy-go"
 )
-
-
 
 // getShardIterator gets a shard iterator after the last sequence number we read or at the start of the stream
 func getShardIterator(k kinsumeriface.KinesisAPI, streamName string, shardID string, sequenceNumber string, iteratorStartTimestamp *time.Time) (string, error) {
@@ -229,14 +228,14 @@ mainloop:
 		// Put all the records we got onto the channel
 		k.config.stats.EventsFromKinesis(len(records), shardID, lag)
 		k.metricsManager.updateMetric(RecordsIncrement, int64(len(records)))
-		
+
 		// Calculate total payload bytes in the batch
 		totalBytes := int64(0)
 		for _, record := range records {
 			totalBytes += int64(len(record.Data))
 		}
 		k.metricsManager.updateMetric(BytesIncrement, totalBytes)
-		
+
 		// Track records for cleanup in case of early return
 		recordsToCleanup := int64(len(records))
 		bytesToCleanup := totalBytes
@@ -249,7 +248,7 @@ mainloop:
 				k.metricsManager.updateMetric(BytesDecrement, bytesToCleanup)
 			}
 		}()
-		
+
 		if len(records) > 0 {
 			retrievedAt := time.Now()
 			for _, record := range records {
@@ -275,8 +274,8 @@ mainloop:
 						retrievedAt:  retrievedAt,
 						payloadBytes: recordPayloadBytes,
 					}:
-						recordsToCleanup-- // Record successfully sent to channel
-						bytesToCleanup -= recordPayloadBytes // Decrement bytes for successfully sent record
+						recordsToCleanup--                         // Record successfully sent to channel
+						bytesToCleanup -= recordPayloadBytes       // Decrement bytes for successfully sent record
 						checkpointer.lastRecordPassed = time.Now() // Mark the time so we don't retain shards when we're too slow to do so
 						lastSeqToCheckp = aws.ToString(record.SequenceNumber)
 						break RecordLoop
@@ -287,7 +286,7 @@ mainloop:
 			// Update the last sequence number we saw, in case we reached the end of the stream.
 			lastSeqNum = aws.ToString(records[len(records)-1].SequenceNumber)
 		}
-		
+
 		// Release semaphore after successfully processing all records from this batch
 		releaseSemaphore()
 		iterator = next

--- a/statreceiver.go
+++ b/statreceiver.go
@@ -41,10 +41,48 @@ type StatReceiver interface {
 	RecordsInMemoryBytes(bytes int64)
 }
 
-// ConfigurableStatReceiver is an optional interface for StatReceivers that support
-// selective metric filtering. StatReceivers that implement this interface can be
-// configured to only send specific metrics.
-type ConfigurableStatReceiver interface {
-	StatReceiver
-	WithMetricsConfig(MetricsConfig) StatReceiver
+// filteredStatReceiver wraps a StatReceiver and filters method calls based on MetricsConfig
+// This allows selective enabling/disabling of metrics at the configuration level
+type filteredStatReceiver struct {
+	underlying StatReceiver
+	config     MetricsConfig
 }
+
+// newFilteredStatReceiver creates a new filteredStatReceiver that wraps the underlying StatReceiver
+func newFilteredStatReceiver(underlying StatReceiver, config MetricsConfig) StatReceiver {
+	return &filteredStatReceiver{
+		underlying: underlying,
+		config:     config,
+	}
+}
+
+func (f *filteredStatReceiver) Checkpoint() {
+	if f.config.EnableCheckpoint {
+		f.underlying.Checkpoint()
+	}
+}
+
+func (f *filteredStatReceiver) EventToClient(inserted, retrieved time.Time) {
+	if f.config.EnableEventToClient {
+		f.underlying.EventToClient(inserted, retrieved)
+	}
+}
+
+func (f *filteredStatReceiver) EventsFromKinesis(num int, shardID string, lag time.Duration) {
+	if f.config.EnableEventsFromKinesis {
+		f.underlying.EventsFromKinesis(num, shardID, lag)
+	}
+}
+
+func (f *filteredStatReceiver) RecordsInMemory(count int64) {
+	if f.config.EnableRecordsInMemory {
+		f.underlying.RecordsInMemory(count)
+	}
+}
+
+func (f *filteredStatReceiver) RecordsInMemoryBytes(bytes int64) {
+	if f.config.EnableRecordsInMemoryBytes {
+		f.underlying.RecordsInMemoryBytes(bytes)
+	}
+}
+

--- a/statreceiver.go
+++ b/statreceiver.go
@@ -85,4 +85,3 @@ func (f *filteredStatReceiver) RecordsInMemoryBytes(bytes int64) {
 		f.underlying.RecordsInMemoryBytes(bytes)
 	}
 }
-

--- a/statreceiver_test.go
+++ b/statreceiver_test.go
@@ -21,7 +21,6 @@ type TestStatReceiver struct {
 	checkpointCalls           int
 	eventToClientCalls        int
 	eventsFromKinesisCalls    []EventsFromKinesisCall
-	config                    *MetricsConfig // nil means all enabled
 }
 
 // EventsFromKinesisCall captures the parameters of EventsFromKinesis calls
@@ -31,60 +30,44 @@ type EventsFromKinesisCall struct {
 	Lag     time.Duration
 }
 
-// WithMetricsConfig implements the ConfigurableStatReceiver interface
-func (t *TestStatReceiver) WithMetricsConfig(config MetricsConfig) StatReceiver {
-	return &TestStatReceiver{
-		config: &config,
-	}
-}
 
 // Checkpoint captures checkpoint calls
 func (t *TestStatReceiver) Checkpoint() {
-	if t.config == nil || t.config.EnableCheckpoint {
-		t.mu.Lock()
-		defer t.mu.Unlock()
-		t.checkpointCalls++
-	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.checkpointCalls++
 }
 
 // EventToClient captures event to client calls
 func (t *TestStatReceiver) EventToClient(inserted, retrieved time.Time) {
-	if t.config == nil || t.config.EnableEventToClient {
-		t.mu.Lock()
-		defer t.mu.Unlock()
-		t.eventToClientCalls++
-	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.eventToClientCalls++
 }
 
 // EventsFromKinesis captures events from kinesis calls
 func (t *TestStatReceiver) EventsFromKinesis(num int, shardID string, lag time.Duration) {
-	if t.config == nil || t.config.EnableEventsFromKinesis {
-		t.mu.Lock()
-		defer t.mu.Unlock()
-		t.eventsFromKinesisCalls = append(t.eventsFromKinesisCalls, EventsFromKinesisCall{
-			Num:     num,
-			ShardID: shardID,
-			Lag:     lag,
-		})
-	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.eventsFromKinesisCalls = append(t.eventsFromKinesisCalls, EventsFromKinesisCall{
+		Num:     num,
+		ShardID: shardID,
+		Lag:     lag,
+	})
 }
 
 // RecordsInMemory captures records in memory calls
 func (t *TestStatReceiver) RecordsInMemory(count int64) {
-	if t.config == nil || t.config.EnableRecordsInMemory {
-		t.mu.Lock()
-		defer t.mu.Unlock()
-		t.recordsInMemoryCalls = append(t.recordsInMemoryCalls, count)
-	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.recordsInMemoryCalls = append(t.recordsInMemoryCalls, count)
 }
 
 // RecordsInMemoryBytes captures records in memory bytes calls
 func (t *TestStatReceiver) RecordsInMemoryBytes(bytes int64) {
-	if t.config == nil || t.config.EnableRecordsInMemoryBytes {
-		t.mu.Lock()
-		defer t.mu.Unlock()
-		t.recordsInMemoryBytesCalls = append(t.recordsInMemoryBytesCalls, bytes)
-	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.recordsInMemoryBytesCalls = append(t.recordsInMemoryBytesCalls, bytes)
 }
 
 // Helper methods for testing
@@ -277,7 +260,7 @@ func TestMetricsBasic(t *testing.T) {
 		recordCalls, byteCalls)
 }
 
-// TestMetricsFiltering tests that metrics can be selectively enabled/disabled
+// TestMetricsFiltering tests that metrics can be selectively enabled/disabled using the filteredStatReceiver
 func TestMetricsFiltering(t *testing.T) {
 	// Test that only RecordsInMemory metrics are captured when others are disabled
 	testStats := &TestStatReceiver{}
@@ -288,28 +271,69 @@ func TestMetricsFiltering(t *testing.T) {
 		// All others default to false
 	}
 	
-	// Apply filtering using the TestStatReceiver's WithMetricsConfig method
-	filteredStats, ok := interface{}(testStats).(ConfigurableStatReceiver)
-	if !ok {
-		t.Skip("TestStatReceiver doesn't implement ConfigurableStatReceiver, skipping filtering test")
-	}
+	// Create a filtered stat receiver using the new approach (simulating WithStats behavior)
+	filteredStats := newFilteredStatReceiver(testStats, metricsConfig)
 	
-	configuredStats := filteredStats.WithMetricsConfig(metricsConfig)
+	// Call all methods on the filtered receiver
+	filteredStats.Checkpoint()
+	filteredStats.EventToClient(time.Now(), time.Now())
+	filteredStats.EventsFromKinesis(5, "shard-001", time.Second)
+	filteredStats.RecordsInMemory(100)
+	filteredStats.RecordsInMemoryBytes(500)
 	
-	// Call all methods
-	configuredStats.Checkpoint()
-	configuredStats.EventToClient(time.Now(), time.Now())
-	configuredStats.EventsFromKinesis(5, "shard-001", time.Second)
-	configuredStats.RecordsInMemory(100)
-	configuredStats.RecordsInMemoryBytes(500)
-	
-	// Verify only RecordsInMemory was called
-	receiverStats := configuredStats.(*TestStatReceiver)
-	recordCount, byteCount, checkpointCount, eventToClientCount, eventsFromKinesisCount := receiverStats.GetCallCounts()
+	// Verify only RecordsInMemory was called on the underlying receiver
+	recordCount, byteCount, checkpointCount, eventToClientCount, eventsFromKinesisCount := testStats.GetCallCounts()
 	
 	assert.Equal(t, 1, recordCount, "Should have 1 RecordsInMemory call")
 	assert.Equal(t, 0, byteCount, "Should have 0 RecordsInMemoryBytes calls (disabled)")
 	assert.Equal(t, 0, checkpointCount, "Should have 0 Checkpoint calls (disabled)")
 	assert.Equal(t, 0, eventToClientCount, "Should have 0 EventToClient calls (disabled)")
 	assert.Equal(t, 0, eventsFromKinesisCount, "Should have 0 EventsFromKinesis calls (disabled)")
+}
+
+// TestMetricsFilteringOrderIndependence tests that the order of WithStats() and WithMetricsConfig() doesn't matter
+func TestMetricsFilteringOrderIndependence(t *testing.T) {
+	testStats1 := &TestStatReceiver{}
+	testStats2 := &TestStatReceiver{}
+	
+	metricsConfig := MetricsConfig{
+		EnableRecordsInMemory: true,
+		// All others default to false
+	}
+	
+	// Test order 1: WithStats first, then WithMetricsConfig
+	config1 := NewConfig().
+		WithStats(testStats1).
+		WithMetricsConfig(metricsConfig)
+	
+	// Test order 2: WithMetricsConfig first, then WithStats  
+	config2 := NewConfig().
+		WithMetricsConfig(metricsConfig).
+		WithStats(testStats2)
+	
+	// Simulate what happens in NewWithInterfaces - apply the filtering
+	filteredStats1 := newFilteredStatReceiver(config1.stats, config1.metricsConfig)
+	filteredStats2 := newFilteredStatReceiver(config2.stats, config2.metricsConfig)
+	
+	// Call all methods on both filtered receivers
+	filteredStats1.Checkpoint()
+	filteredStats1.RecordsInMemory(100)
+	filteredStats1.RecordsInMemoryBytes(500)
+	
+	filteredStats2.Checkpoint() 
+	filteredStats2.RecordsInMemory(100)
+	filteredStats2.RecordsInMemoryBytes(500)
+	
+	// Both should have identical behavior regardless of order
+	recordCount1, byteCount1, checkpointCount1, _, _ := testStats1.GetCallCounts()
+	recordCount2, byteCount2, checkpointCount2, _, _ := testStats2.GetCallCounts()
+	
+	assert.Equal(t, recordCount1, recordCount2, "RecordsInMemory calls should be identical regardless of order")
+	assert.Equal(t, byteCount1, byteCount2, "RecordsInMemoryBytes calls should be identical regardless of order") 
+	assert.Equal(t, checkpointCount1, checkpointCount2, "Checkpoint calls should be identical regardless of order")
+	
+	// Verify the expected filtering (only RecordsInMemory should be called)
+	assert.Equal(t, 1, recordCount1, "Should have 1 RecordsInMemory call")
+	assert.Equal(t, 0, byteCount1, "Should have 0 RecordsInMemoryBytes calls (disabled)")
+	assert.Equal(t, 0, checkpointCount1, "Should have 0 Checkpoint calls (disabled)")
 }

--- a/statreceiver_test.go
+++ b/statreceiver_test.go
@@ -30,7 +30,6 @@ type EventsFromKinesisCall struct {
 	Lag     time.Duration
 }
 
-
 // Checkpoint captures checkpoint calls
 func (t *TestStatReceiver) Checkpoint() {
 	t.mu.Lock()
@@ -256,7 +255,7 @@ func TestMetricsBasic(t *testing.T) {
 	assert.True(t, hasNonZeroRecords, "Should have non-zero records in memory at some point")
 	assert.True(t, hasNonZeroBytes, "Should have non-zero bytes in memory at some point")
 
-	t.Logf("✓ Metrics test completed - RecordsInMemory calls: %v, RecordsInMemoryBytes calls: %v", 
+	t.Logf("✓ Metrics test completed - RecordsInMemory calls: %v, RecordsInMemoryBytes calls: %v",
 		recordCalls, byteCalls)
 }
 
@@ -264,26 +263,26 @@ func TestMetricsBasic(t *testing.T) {
 func TestMetricsFiltering(t *testing.T) {
 	// Test that only RecordsInMemory metrics are captured when others are disabled
 	testStats := &TestStatReceiver{}
-	
+
 	// Configure to only enable RecordsInMemory
 	metricsConfig := MetricsConfig{
 		EnableRecordsInMemory: true,
 		// All others default to false
 	}
-	
+
 	// Create a filtered stat receiver using the new approach (simulating WithStats behavior)
 	filteredStats := newFilteredStatReceiver(testStats, metricsConfig)
-	
+
 	// Call all methods on the filtered receiver
 	filteredStats.Checkpoint()
 	filteredStats.EventToClient(time.Now(), time.Now())
 	filteredStats.EventsFromKinesis(5, "shard-001", time.Second)
 	filteredStats.RecordsInMemory(100)
 	filteredStats.RecordsInMemoryBytes(500)
-	
+
 	// Verify only RecordsInMemory was called on the underlying receiver
 	recordCount, byteCount, checkpointCount, eventToClientCount, eventsFromKinesisCount := testStats.GetCallCounts()
-	
+
 	assert.Equal(t, 1, recordCount, "Should have 1 RecordsInMemory call")
 	assert.Equal(t, 0, byteCount, "Should have 0 RecordsInMemoryBytes calls (disabled)")
 	assert.Equal(t, 0, checkpointCount, "Should have 0 Checkpoint calls (disabled)")
@@ -295,43 +294,43 @@ func TestMetricsFiltering(t *testing.T) {
 func TestMetricsFilteringOrderIndependence(t *testing.T) {
 	testStats1 := &TestStatReceiver{}
 	testStats2 := &TestStatReceiver{}
-	
+
 	metricsConfig := MetricsConfig{
 		EnableRecordsInMemory: true,
 		// All others default to false
 	}
-	
+
 	// Test order 1: WithStats first, then WithMetricsConfig
 	config1 := NewConfig().
 		WithStats(testStats1).
 		WithMetricsConfig(metricsConfig)
-	
-	// Test order 2: WithMetricsConfig first, then WithStats  
+
+	// Test order 2: WithMetricsConfig first, then WithStats
 	config2 := NewConfig().
 		WithMetricsConfig(metricsConfig).
 		WithStats(testStats2)
-	
+
 	// Simulate what happens in NewWithInterfaces - apply the filtering
 	filteredStats1 := newFilteredStatReceiver(config1.stats, config1.metricsConfig)
 	filteredStats2 := newFilteredStatReceiver(config2.stats, config2.metricsConfig)
-	
+
 	// Call all methods on both filtered receivers
 	filteredStats1.Checkpoint()
 	filteredStats1.RecordsInMemory(100)
 	filteredStats1.RecordsInMemoryBytes(500)
-	
-	filteredStats2.Checkpoint() 
+
+	filteredStats2.Checkpoint()
 	filteredStats2.RecordsInMemory(100)
 	filteredStats2.RecordsInMemoryBytes(500)
-	
+
 	// Both should have identical behavior regardless of order
 	recordCount1, byteCount1, checkpointCount1, _, _ := testStats1.GetCallCounts()
 	recordCount2, byteCount2, checkpointCount2, _, _ := testStats2.GetCallCounts()
-	
+
 	assert.Equal(t, recordCount1, recordCount2, "RecordsInMemory calls should be identical regardless of order")
-	assert.Equal(t, byteCount1, byteCount2, "RecordsInMemoryBytes calls should be identical regardless of order") 
+	assert.Equal(t, byteCount1, byteCount2, "RecordsInMemoryBytes calls should be identical regardless of order")
 	assert.Equal(t, checkpointCount1, checkpointCount2, "Checkpoint calls should be identical regardless of order")
-	
+
 	// Verify the expected filtering (only RecordsInMemory should be called)
 	assert.Equal(t, 1, recordCount1, "Should have 1 RecordsInMemory call")
 	assert.Equal(t, 0, byteCount1, "Should have 0 RecordsInMemoryBytes calls (disabled)")

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -19,8 +19,8 @@ func New(addr, prefix string) (*Statsd, error) {
 	sd, err := statsd.NewClientWithConfig(&statsd.ClientConfig{
 		Address:       addr,
 		Prefix:        prefix,
-		UseBuffered:   true,                    // Enable buffering by default
-		FlushInterval: 1 * time.Second,        // Sensible default flush interval
+		UseBuffered:   true,            // Enable buffering by default
+		FlushInterval: 1 * time.Second, // Sensible default flush interval
 	})
 
 	if err != nil {
@@ -37,7 +37,6 @@ func NewWithStatter(client statsd.StatSender) *Statsd {
 		client: client,
 	}
 }
-
 
 // Checkpoint implementation that writes to statsd
 func (s *Statsd) Checkpoint() {

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -7,13 +7,11 @@ import (
 	"time"
 
 	"github.com/cactus/go-statsd-client/statsd"
-	"github.com/twitchscience/kinsumer"
 )
 
 // Statsd is a statreceiver that writes stats to a statsd endpoint
 type Statsd struct {
 	client statsd.StatSender
-	config *kinsumer.MetricsConfig // nil means all metrics enabled
 }
 
 // New creates a new Statsd statreceiver with buffering enabled by default
@@ -40,56 +38,38 @@ func NewWithStatter(client statsd.StatSender) *Statsd {
 	}
 }
 
-// WithMetricsConfig creates a new Statsd with the specified metrics configuration
-// This implements the ConfigurableStatReceiver interface
-func (s *Statsd) WithMetricsConfig(config kinsumer.MetricsConfig) kinsumer.StatReceiver {
-	return &Statsd{
-		client: s.client,
-		config: &config,
-	}
-}
 
 // Checkpoint implementation that writes to statsd
 func (s *Statsd) Checkpoint() {
-	if s.config == nil || s.config.EnableCheckpoint {
-		_ = s.client.Inc("kinsumer.checkpoints", 1, 1.0)
-	}
+	_ = s.client.Inc("kinsumer.checkpoints", 1, 1.0)
 }
 
 // EventToClient implementation that writes to statsd metrics about a record
 // that was consumed by the client
 func (s *Statsd) EventToClient(inserted, retrieved time.Time) {
-	if s.config == nil || s.config.EnableEventToClient {
-		now := time.Now()
+	now := time.Now()
 
-		_ = s.client.Inc("kinsumer.consumed", 1, 1.0)
-		_ = s.client.TimingDuration("kinsumer.in_stream", retrieved.Sub(inserted), 1.0)
-		_ = s.client.TimingDuration("kinsumer.end_to_end", now.Sub(inserted), 1.0)
-		_ = s.client.TimingDuration("kinsumer.in_kinsumer", now.Sub(retrieved), 1.0)
-	}
+	_ = s.client.Inc("kinsumer.consumed", 1, 1.0)
+	_ = s.client.TimingDuration("kinsumer.in_stream", retrieved.Sub(inserted), 1.0)
+	_ = s.client.TimingDuration("kinsumer.end_to_end", now.Sub(inserted), 1.0)
+	_ = s.client.TimingDuration("kinsumer.in_kinsumer", now.Sub(retrieved), 1.0)
 }
 
 // EventsFromKinesis implementation that writes to statsd metrics about records that
 // were retrieved from kinesis
 func (s *Statsd) EventsFromKinesis(num int, shardID string, lag time.Duration) {
-	if s.config == nil || s.config.EnableEventsFromKinesis {
-		_ = s.client.TimingDuration(fmt.Sprintf("kinsumer.%s.lag", shardID), lag, 1.0)
-		_ = s.client.Inc(fmt.Sprintf("kinsumer.%s.retrieved", shardID), int64(num), 1.0)
-	}
+	_ = s.client.TimingDuration(fmt.Sprintf("kinsumer.%s.lag", shardID), lag, 1.0)
+	_ = s.client.Inc(fmt.Sprintf("kinsumer.%s.retrieved", shardID), int64(num), 1.0)
 }
 
 // RecordsInMemory implementation that writes to statsd a gauge metric about
 // the current number of records buffered in memory
 func (s *Statsd) RecordsInMemory(count int64) {
-	if s.config == nil || s.config.EnableRecordsInMemory {
-		_ = s.client.Gauge("kinsumer.records_in_memory", count, 1.0)
-	}
+	_ = s.client.Gauge("kinsumer.records_in_memory", count, 1.0)
 }
 
 // RecordsInMemoryBytes implementation that writes to statsd a gauge metric about
 // the current total payload bytes buffered in memory
 func (s *Statsd) RecordsInMemoryBytes(bytes int64) {
-	if s.config == nil || s.config.EnableRecordsInMemoryBytes {
-		_ = s.client.Gauge("kinsumer.records_in_memory_bytes", bytes, 1.0)
-	}
+	_ = s.client.Gauge("kinsumer.records_in_memory_bytes", bytes, 1.0)
 }


### PR DESCRIPTION
Followup PR to clean up config per [this comment](https://github.com/snowplow-devops/kinsumer/pull/34#discussion_r2336308287).

Because of how the statreceiver is passed to checkpointer, basic ifs were difficult to make cleaner - so landed on a wrapper on initialisation which I think cleans up the implementation across the board.