### PR TITLE
Release/1.7.0

### DIFF
--- a/config.go
+++ b/config.go
@@ -52,6 +52,11 @@ type Config struct {
 
 	// use ListShards to avoid LimitExceedException from DescribeStream
 	useListShardsForKinesisStreamReady bool
+
+	// Maximum number of records to fetch per GetRecords request
+	// AWS Kinesis allows up to 10,000 records per request (default)
+	// Reducing this value helps control memory usage at the cost of increased API calls
+	getRecordsLimit int
 }
 
 // NewConfig returns a default Config struct
@@ -67,6 +72,7 @@ func NewConfig() Config {
 		dynamoWriteCapacity:   10,
 		dynamoWaiterDelay:     3 * time.Second,
 		logger:                &DefaultLogger{},
+		getRecordsLimit:       10000,
 	}
 }
 
@@ -157,6 +163,14 @@ func (c Config) WithUseListShardsForKinesisStreamReady(shouldUse bool) Config {
 	return c
 }
 
+// WithGetRecordsLimit returns a Config with a modified maximum records per GetRecords request
+// This controls how many records to fetch per GetRecords API call.
+// AWS Kinesis allows up to 10,000 records per request. Reducing this helps control memory usage.
+func (c Config) WithGetRecordsLimit(getRecordsLimit int) Config {
+	c.getRecordsLimit = getRecordsLimit
+	return c
+}
+
 // Verify that a config struct has sane and valid values
 func validateConfig(c *Config) error {
 	if c.throttleDelay < 200*time.Millisecond {
@@ -197,6 +211,10 @@ func validateConfig(c *Config) error {
 
 	if c.logger == nil {
 		return ErrConfigInvalidLogger
+	}
+
+	if c.getRecordsLimit <= 0 || c.getRecordsLimit > 10000 {
+		return ErrConfigInvalidGetRecordsLimit
 	}
 
 	return nil

--- a/config.go
+++ b/config.go
@@ -57,6 +57,14 @@ type Config struct {
 	// AWS Kinesis allows up to 10,000 records per request (default)
 	// Reducing this value helps control memory usage at the cost of increased API calls
 	getRecordsLimit int
+	// ---------- [ Memory Management ] ----------
+	// Maximum number of shards that can fetch records from Kinesis concurrently
+	// 0 (default) means unlimited concurrent shards
+	// Setting this helps prevent memory exhaustion during scaling events when a single
+	// client temporarily handles many shards. With random data distribution across shards,
+	// this provides natural fairness over time while controlling peak memory usage.
+	// Example: Setting to 20 limits memory to ~20 * 10k records * avg_record_size
+	maxConcurrentShards int
 }
 
 // NewConfig returns a default Config struct
@@ -171,6 +179,15 @@ func (c Config) WithGetRecordsLimit(getRecordsLimit int) Config {
 	return c
 }
 
+// WithMaxConcurrentShards returns a Config with a modified maximum concurrent shard limit
+// This controls how many shards can fetch records from Kinesis simultaneously.
+// Setting this helps prevent memory pressure during scaling events.
+// 0 (default) means unlimited concurrent shards.
+func (c Config) WithMaxConcurrentShards(maxConcurrentShards int) Config {
+	c.maxConcurrentShards = maxConcurrentShards
+	return c
+}
+
 // Verify that a config struct has sane and valid values
 func validateConfig(c *Config) error {
 	if c.throttleDelay < 200*time.Millisecond {
@@ -215,6 +232,9 @@ func validateConfig(c *Config) error {
 
 	if c.getRecordsLimit <= 0 || c.getRecordsLimit > 10000 {
 		return ErrConfigInvalidGetRecordsLimit
+	}
+	if c.maxConcurrentShards < 0 {
+		return ErrConfigInvalidMaxConcurrentShards
 	}
 
 	return nil

--- a/config.go
+++ b/config.go
@@ -6,6 +6,26 @@ import (
 	"time"
 )
 
+// MetricsConfig controls which metrics are sent to the StatReceiver
+type MetricsConfig struct {
+	EnableCheckpoint           bool
+	EnableEventToClient        bool
+	EnableEventsFromKinesis    bool
+	EnableRecordsInMemory      bool
+	EnableRecordsInMemoryBytes bool
+}
+
+// NewMetricsConfig returns a MetricsConfig with all metrics enabled (backward compatibility)
+func NewMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		EnableCheckpoint:           true,
+		EnableEventToClient:        true,
+		EnableEventsFromKinesis:    true,
+		EnableRecordsInMemory:      true,
+		EnableRecordsInMemoryBytes: true,
+	}
+}
+
 //TODO: Update documentation to include the defaults
 //TODO: Update the 'with' methods' comments to be less ridiculous
 
@@ -65,6 +85,7 @@ type Config struct {
 	// this provides natural fairness over time while controlling peak memory usage.
 	// Example: Setting to 20 limits memory to ~20 * 10k records * avg_record_size
 	maxConcurrentShards int
+	metricsConfig       MetricsConfig
 }
 
 // NewConfig returns a default Config struct
@@ -81,6 +102,7 @@ func NewConfig() Config {
 		dynamoWaiterDelay:     3 * time.Second,
 		logger:                &DefaultLogger{},
 		getRecordsLimit:       10000,
+		metricsConfig:         NewMetricsConfig(),
 	}
 }
 
@@ -129,7 +151,7 @@ func (c Config) WithBufferSize(bufferSize int) Config {
 	return c
 }
 
-// WithStats returns a Config with a modified stats
+// WithStats returns a Config with a modified stats receiver
 func (c Config) WithStats(stats StatReceiver) Config {
 	c.stats = stats
 	return c
@@ -185,6 +207,13 @@ func (c Config) WithGetRecordsLimit(getRecordsLimit int) Config {
 // 0 (default) means unlimited concurrent shards.
 func (c Config) WithMaxConcurrentShards(maxConcurrentShards int) Config {
 	c.maxConcurrentShards = maxConcurrentShards
+	return c
+}
+
+// WithMetricsConfig returns a Config with a modified metrics configuration
+// This controls which metrics are sent to the StatReceiver
+func (c Config) WithMetricsConfig(metricsConfig MetricsConfig) Config {
+	c.metricsConfig = metricsConfig
 	return c
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -52,6 +52,10 @@ func TestConfigErrors(t *testing.T) {
 	config = NewConfig().WithStats(nil)
 	err = validateConfig(&config)
 	require.EqualError(t, err, ErrConfigInvalidStats.Error())
+
+	config = NewConfig().WithMaxConcurrentShards(-1)
+	err = validateConfig(&config)
+	require.EqualError(t, err, ErrConfigInvalidMaxConcurrentShards.Error())
 }
 
 func TestConfigWithMethods(t *testing.T) {
@@ -65,7 +69,8 @@ func TestConfigWithMethods(t *testing.T) {
 		WithThrottleDelay(1 * time.Second).
 		WithStats(stats).
 		WithIteratorStartTimestamp(&tstamp).
-		WithUseListShardsForKinesisStreamReady(true)
+		WithUseListShardsForKinesisStreamReady(true).
+		WithMaxConcurrentShards(10)
 
 	err := validateConfig(&config)
 	require.NoError(t, err)
@@ -78,4 +83,5 @@ func TestConfigWithMethods(t *testing.T) {
 	require.Equal(t, stats, config.stats)
 	require.Equal(t, &tstamp, config.iteratorStartTimestamp)
 	require.Equal(t, true, config.useListShardsForKinesisStreamReady)
+	require.Equal(t, 10, config.maxConcurrentShards)
 }

--- a/errors.go
+++ b/errors.go
@@ -38,6 +38,8 @@ var (
 	ErrConfigInvalidDynamoCapacity = errors.New("dynamo read/write capacity cannot be 0")
 	// ErrConfigInvalidLogger - Logger cannot be nil
 	ErrConfigInvalidLogger = errors.New("logger cannot be nil")
+	// ErrConfigInvalidGetRecordsLimit - getRecordsLimit must be between 1 and 10000
+	ErrConfigInvalidGetRecordsLimit = errors.New("getRecordsLimit must be between 1 and 10000")
 
 	// ErrStreamBusy - Stream is busy
 	ErrStreamBusy = errors.New("stream is busy")

--- a/errors.go
+++ b/errors.go
@@ -40,6 +40,8 @@ var (
 	ErrConfigInvalidLogger = errors.New("logger cannot be nil")
 	// ErrConfigInvalidGetRecordsLimit - getRecordsLimit must be between 1 and 10000
 	ErrConfigInvalidGetRecordsLimit = errors.New("getRecordsLimit must be between 1 and 10000")
+	// ErrConfigInvalidMaxConcurrentShards - maxConcurrentShards must be >= 0
+	ErrConfigInvalidMaxConcurrentShards = errors.New("maxConcurrentShards must be >= 0")
 
 	// ErrStreamBusy - Stream is busy
 	ErrStreamBusy = errors.New("stream is busy")

--- a/kinsumer.go
+++ b/kinsumer.go
@@ -5,10 +5,11 @@ package kinsumer
 import (
 	"context"
 	"fmt"
-	"github.com/twitchscience/kinsumer/kinsumeriface"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/twitchscience/kinsumer/kinsumeriface"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
@@ -31,6 +32,111 @@ type consumedRecord struct {
 	record       *ktypes.Record // Record retrieved from kinesis
 	checkpointer *checkpointer  // Object that will store the checkpoint back to the database
 	retrievedAt  time.Time      // Time the record was retrieved from Kinesis
+	payloadBytes int64          // Size of record.Data payload in bytes
+}
+
+// MetricType represents the type of metric update
+type MetricType int
+
+const (
+	RecordsIncrement MetricType = iota
+	RecordsDecrement
+	BytesIncrement
+	BytesDecrement
+	CombinedDecrement
+)
+
+// MetricUpdate represents a single metric update to be processed
+type MetricUpdate struct {
+	Type         MetricType
+	Value        int64
+	RecordsDelta int64 // For combined updates: change in records count
+	BytesDelta   int64 // For combined updates: change in bytes count
+}
+
+// MetricsManager handles metrics updates through channels to avoid atomic contention
+type MetricsManager struct {
+	updates      chan MetricUpdate
+	stop         chan struct{}
+	recordsCount int64  // Current records count - only written by metrics goroutine
+	bytesCount   int64  // Current bytes count - only written by metrics goroutine
+	logger       Logger // Logger for warnings and errors
+}
+
+// newMetricsManager creates a new MetricsManager with buffered channel
+func newMetricsManager(logger Logger) *MetricsManager {
+	return &MetricsManager{
+		updates: make(chan MetricUpdate, 5000), // Buffer sized for batched writes
+		stop:    make(chan struct{}),
+		logger:  logger,
+	}
+}
+
+// updateMetric sends a non-blocking metric update
+func (mm *MetricsManager) updateMetric(t MetricType, value int64) {
+	select {
+	case mm.updates <- MetricUpdate{Type: t, Value: value}:
+		// Successfully queued
+	default:
+		// Channel full - log immediately since drops should be very rare with batching
+		mm.logger.Log("Warning: metrics channel full, dropping single metric update (type: %d, value: %d)", t, value)
+	}
+}
+
+// decrementCombined sends a combined decrement update for both records and bytes
+func (mm *MetricsManager) decrementCombined(recordsDelta, bytesDelta int64) {
+	select {
+	case mm.updates <- MetricUpdate{
+		Type:         CombinedDecrement,
+		RecordsDelta: recordsDelta,
+		BytesDelta:   bytesDelta,
+	}:
+		// Successfully queued
+	default:
+		// Channel full - log immediately since drops should be very rare with batching
+		mm.logger.Log("Warning: metrics channel full, dropping update with %d records, %d bytes", recordsDelta, bytesDelta)
+	}
+}
+
+// getCurrentMetrics returns current metric values using atomic loads
+func (mm *MetricsManager) getCurrentMetrics() (int64, int64) {
+	return atomic.LoadInt64(&mm.recordsCount), atomic.LoadInt64(&mm.bytesCount)
+}
+
+// run processes metric updates in a separate goroutine
+func (mm *MetricsManager) run() {
+	var recordsCount, bytesCount int64
+
+	for {
+		select {
+		case update := <-mm.updates:
+			switch update.Type {
+			case RecordsIncrement:
+				recordsCount += update.Value
+			case RecordsDecrement:
+				recordsCount -= update.Value
+			case BytesIncrement:
+				bytesCount += update.Value
+			case BytesDecrement:
+				bytesCount -= update.Value
+			case CombinedDecrement:
+				recordsCount -= update.RecordsDelta
+				bytesCount -= update.BytesDelta
+			}
+
+			// Update shared state - single writer, no contention
+			atomic.StoreInt64(&mm.recordsCount, recordsCount)
+			atomic.StoreInt64(&mm.bytesCount, bytesCount)
+
+		case <-mm.stop:
+			return
+		}
+	}
+}
+
+// shutdown stops the metrics goroutine
+func (mm *MetricsManager) shutdown() {
+	close(mm.stop)
 }
 
 // Kinsumer is a Kinesis Consumer that tries to reduce duplicate reads while allowing for multiple
@@ -65,6 +171,9 @@ type Kinsumer struct {
 	maxAgeForClientRecord time.Duration           // Cutoff for client/checkpoint records we read from dynamodb before we assume the record is stale
 	maxAgeForLeaderRecord time.Duration           // Cutoff for leader/shard cache records we read from dynamodb before we assume the record is stale
 	shardSemaphore        chan struct{}           // Semaphore to limit concurrent shard record fetching
+	metricsManager        *MetricsManager         // Channel-based metrics manager to avoid atomic contention
+	pendingRecords        int64                   // Accumulated record decrements for batching
+	pendingBytes          int64                   // Accumulated byte decrements for batching
 }
 
 // New returns a Kinsumer Interface with default kinesis and dynamodb instances, to be used in ec2 instances to get default auth and config
@@ -116,6 +225,12 @@ func NewWithInterfaces(
 		config.clientRecordMaxAge = &maxAge
 	}
 
+	// Wrap the stats receiver with filtering based on metrics configuration
+	// This happens after config validation to ensure we have the final configuration
+	if config.stats != nil {
+		config.stats = newFilteredStatReceiver(config.stats, config.metricsConfig)
+	}
+
 	consumer := &Kinsumer{
 		streamName:            streamName,
 		kinesis:               kinesis,
@@ -133,6 +248,7 @@ func NewWithInterfaces(
 		config:                config,
 		maxAgeForClientRecord: *config.clientRecordMaxAge,
 		maxAgeForLeaderRecord: config.leaderActionFrequency * 5,
+		metricsManager:        newMetricsManager(config.logger),
 	}
 
 	// Initialize semaphore for limiting concurrent shard record fetching
@@ -398,6 +514,9 @@ func (k *Kinsumer) Run() error {
 		return fmt.Errorf("error in kinsumer Run initial refreshShards: %v", err)
 	}
 
+	// Start metrics goroutine
+	go k.metricsManager.run()
+
 	k.mainWG.Add(1)
 	go func() {
 		defer k.mainWG.Done()
@@ -413,6 +532,12 @@ func (k *Kinsumer) Run() error {
 			// Do this outside the k.isLeader check in case k.isLeader was false because
 			// we lost leadership but haven't had time to shutdown the goroutine yet.
 			k.leaderWG.Wait()
+			// Flush any remaining pending metrics before shutdown
+			if k.pendingRecords > 0 || k.pendingBytes > 0 {
+				k.metricsManager.decrementCombined(k.pendingRecords, k.pendingBytes)
+			}
+			// Shutdown metrics goroutine
+			k.metricsManager.shutdown()
 		}()
 
 		// We close k.output so that Next() stops, this is also the reason
@@ -422,6 +547,12 @@ func (k *Kinsumer) Run() error {
 		shardChangeTicker := time.NewTicker(k.config.shardCheckFrequency)
 		defer func() {
 			shardChangeTicker.Stop()
+		}()
+
+		// Report buffer size every 1 seconds
+		bufferReportTicker := time.NewTicker(1 * time.Second)
+		defer func() {
+			bufferReportTicker.Stop()
 		}()
 
 		var record *consumedRecord
@@ -454,6 +585,13 @@ func (k *Kinsumer) Run() error {
 				if !k.config.manualCheckpointing {
 					record.checkpointer.update(aws.ToString(record.record.SequenceNumber))
 				}
+				k.pendingRecords++
+				k.pendingBytes += record.payloadBytes
+				if k.pendingRecords >= 50 {
+					k.metricsManager.decrementCombined(k.pendingRecords, k.pendingBytes)
+					k.pendingRecords = 0
+					k.pendingBytes = 0
+				}
 				record = nil
 			case se := <-k.shardErrors:
 				k.errors <- fmt.Errorf("shard error (%s) in %s: %s", se.shardID, se.action, se.err)
@@ -480,6 +618,12 @@ func (k *Kinsumer) Run() error {
 
 					k.isRestartingConsumers = false
 				}
+			case <-bufferReportTicker.C:
+				// Report the current number of records pulled from Kinesis but not yet delivered to client
+				recordsCount, bytesCount := k.metricsManager.getCurrentMetrics()
+				k.config.stats.RecordsInMemory(recordsCount)
+				// Report the current total bytes of record payloads pulled from Kinesis but not yet delivered to client
+				k.config.stats.RecordsInMemoryBytes(bytesCount)
 			}
 		}
 	}()

--- a/kinsumer.go
+++ b/kinsumer.go
@@ -64,6 +64,7 @@ type Kinsumer struct {
 	leaderWG              sync.WaitGroup          // waitGroup for the leader loop
 	maxAgeForClientRecord time.Duration           // Cutoff for client/checkpoint records we read from dynamodb before we assume the record is stale
 	maxAgeForLeaderRecord time.Duration           // Cutoff for leader/shard cache records we read from dynamodb before we assume the record is stale
+	shardSemaphore        chan struct{}           // Semaphore to limit concurrent shard record fetching
 }
 
 // New returns a Kinsumer Interface with default kinesis and dynamodb instances, to be used in ec2 instances to get default auth and config
@@ -132,6 +133,11 @@ func NewWithInterfaces(
 		config:                config,
 		maxAgeForClientRecord: *config.clientRecordMaxAge,
 		maxAgeForLeaderRecord: config.leaderActionFrequency * 5,
+	}
+
+	// Initialize semaphore for limiting concurrent shard record fetching
+	if config.maxConcurrentShards > 0 {
+		consumer.shardSemaphore = make(chan struct{}, config.maxConcurrentShards)
 	}
 	return consumer, nil
 }

--- a/mocks/dynamo.go
+++ b/mocks/dynamo.go
@@ -6,11 +6,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
+	"testing"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/twitchscience/kinsumer/kinsumeriface"
-	"testing"
 )
 
 var (
@@ -51,6 +53,9 @@ type mockDynamoCallRecord struct {
 type MockDynamo struct {
 	kinsumeriface.DynamoDBAPI
 
+	// Thread safety
+	mu sync.Mutex
+
 	// Stored data
 	tables map[string][]mockDynamoItem
 
@@ -75,6 +80,8 @@ func (d *MockDynamo) addTable(name string) {
 }
 
 func (d *MockDynamo) recordCall(operation string, in, out interface{}, err error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	d.requests = append(d.requests, mockDynamoCallRecord{
 		operation: operation,
 		input:     in,
@@ -96,6 +103,9 @@ func (d *MockDynamo) PutItem(ctx context.Context, in *dynamodb.PutItemInput, opt
 	if aws.ToString(in.TableName) == mockDynamoErrorTrigger {
 		return nil, errInternalError()
 	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
 
 	tableName := aws.ToString(in.TableName)
 	if _, ok := d.tables[tableName]; !ok {
@@ -132,6 +142,9 @@ func (d *MockDynamo) GetItem(ctx context.Context, in *dynamodb.GetItemInput, opt
 	if aws.ToString(in.TableName) == mockDynamoErrorTrigger {
 		return nil, errInternalError()
 	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
 
 	tableName := aws.ToString(in.TableName)
 	if _, ok := d.tables[tableName]; !ok {

--- a/mocks/kinesis.go
+++ b/mocks/kinesis.go
@@ -1,0 +1,350 @@
+// Copyright (c) 2016 Twitch Interactive
+
+package mocks
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/kinesis"
+	"github.com/aws/aws-sdk-go-v2/service/kinesis/types"
+	"github.com/twitchscience/kinsumer/kinsumeriface"
+)
+
+// mockKinesisCallRecord tracks individual calls to MockKinesis methods
+type mockKinesisCallRecord struct {
+	operation string
+	shardID   string
+	startTime time.Time
+	endTime   time.Time
+	err       error
+}
+
+// MockKinesis mocks the Kinesis API in memory with call tracking and concurrency monitoring
+type MockKinesis struct {
+	kinsumeriface.KinesisAPI
+
+	mu sync.Mutex
+
+	// Call tracking
+	calls         []mockKinesisCallRecord
+	activeCalls   int
+	maxConcurrent int
+	totalCalls    int
+
+	// Configuration
+	delay                         time.Duration
+	shouldError                   bool
+	errorTriggerShard             string
+	useGenericError               bool
+	shouldErrorOnGetShardIterator bool
+
+	// Mock data
+	shards       map[string]*mockShard
+	streamStatus string
+}
+
+type mockShard struct {
+	shardID      string
+	records      []types.Record
+	iterator     string
+	nextIterator string
+	closed       bool
+}
+
+// NewMockKinesis creates a new MockKinesis with the specified shards
+func NewMockKinesis(shardIDs []string) *MockKinesis {
+	mk := &MockKinesis{
+		calls:        make([]mockKinesisCallRecord, 0),
+		shards:       make(map[string]*mockShard),
+		streamStatus: "ACTIVE",
+	}
+
+	// Create mock shards
+	for _, shardID := range shardIDs {
+		mk.shards[shardID] = &mockShard{
+			shardID:      shardID,
+			records:      make([]types.Record, 0),
+			iterator:     "iter-" + shardID + "-0",
+			nextIterator: "iter-" + shardID + "-1",
+			closed:       false,
+		}
+
+		// Add some mock records for each shard
+		for j := 0; j < 10; j++ {
+			recordData := []byte("record-" + shardID + "-" + fmt.Sprintf("%d", j))
+			mk.shards[shardID].records = append(mk.shards[shardID].records, types.Record{
+				Data:           recordData,
+				PartitionKey:   aws.String("partition-" + shardID),
+				SequenceNumber: aws.String("seq-" + shardID + "-" + fmt.Sprintf("%d", j)),
+			})
+		}
+	}
+
+	return mk
+}
+
+// SetDelay configures artificial delay for GetRecords calls
+func (mk *MockKinesis) SetDelay(delay time.Duration) {
+	mk.mu.Lock()
+	defer mk.mu.Unlock()
+	mk.delay = delay
+}
+
+// SetError configures GetRecords to return errors for a specific shard
+func (mk *MockKinesis) SetError(shardID string, shouldError bool) {
+	mk.mu.Lock()
+	defer mk.mu.Unlock()
+	mk.errorTriggerShard = shardID
+	mk.shouldError = shouldError
+}
+
+// SetGenericError configures GetRecords to return a generic error (not ExpiredIteratorException)
+func (mk *MockKinesis) SetGenericError(shardID string) {
+	mk.mu.Lock()
+	defer mk.mu.Unlock()
+	mk.errorTriggerShard = shardID
+	mk.shouldError = true
+	mk.useGenericError = true
+}
+
+// SetEmptyRecords configures GetRecords to return empty records for a specific shard
+func (mk *MockKinesis) SetEmptyRecords(shardID string) {
+	mk.mu.Lock()
+	defer mk.mu.Unlock()
+	if shard, exists := mk.shards[shardID]; exists {
+		shard.records = []types.Record{} // Clear all records
+	}
+}
+
+// SetBothGetRecordsAndGetShardIteratorErrors configures both GetRecords and GetShardIterator to fail
+func (mk *MockKinesis) SetBothGetRecordsAndGetShardIteratorErrors(shardID string) {
+	mk.mu.Lock()
+	defer mk.mu.Unlock()
+	mk.errorTriggerShard = shardID
+	mk.shouldError = true
+	mk.useGenericError = false // Use ExpiredIteratorException for GetRecords
+	mk.shouldErrorOnGetShardIterator = true
+}
+
+// GetMaxConcurrentCalls returns the maximum concurrent calls observed
+func (mk *MockKinesis) GetMaxConcurrentCalls() int {
+	mk.mu.Lock()
+	defer mk.mu.Unlock()
+	return mk.maxConcurrent
+}
+
+// GetCurrentActiveCalls returns the current number of active calls
+func (mk *MockKinesis) GetCurrentActiveCalls() int {
+	mk.mu.Lock()
+	defer mk.mu.Unlock()
+	return mk.activeCalls
+}
+
+// GetTotalCalls returns total number of GetRecords calls made
+func (mk *MockKinesis) GetTotalCalls() int {
+	mk.mu.Lock()
+	defer mk.mu.Unlock()
+	return mk.totalCalls
+}
+
+// WaitForConcurrentCalls blocks until the specified number of concurrent calls is reached
+func (mk *MockKinesis) WaitForConcurrentCalls(targetCount int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		mk.mu.Lock()
+		current := mk.activeCalls
+		mk.mu.Unlock()
+
+		if current >= targetCount {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false
+}
+
+// recordCall tracks a method call
+func (mk *MockKinesis) recordCall(operation, shardID string, err error) {
+	call := mockKinesisCallRecord{
+		operation: operation,
+		shardID:   shardID,
+		startTime: time.Now(),
+		err:       err,
+	}
+	mk.calls = append(mk.calls, call)
+}
+
+// GetShardIterator mocks the Kinesis GetShardIterator operation
+func (mk *MockKinesis) GetShardIterator(ctx context.Context, input *kinesis.GetShardIteratorInput, optFns ...func(*kinesis.Options)) (*kinesis.GetShardIteratorOutput, error) {
+	mk.mu.Lock()
+	defer mk.mu.Unlock()
+
+	shardID := aws.ToString(input.ShardId)
+
+	// Check for configured errors
+	if mk.shouldErrorOnGetShardIterator && shardID == mk.errorTriggerShard {
+		mk.recordCall("GetShardIterator", shardID, fmt.Errorf("simulated GetShardIterator error"))
+		return nil, fmt.Errorf("simulated GetShardIterator error")
+	}
+
+	mk.recordCall("GetShardIterator", shardID, nil)
+
+	shard, exists := mk.shards[shardID]
+	if !exists {
+		return nil, &types.ResourceNotFoundException{Message: aws.String("Shard not found")}
+	}
+
+	return &kinesis.GetShardIteratorOutput{
+		ShardIterator: &shard.iterator,
+	}, nil
+}
+
+// GetRecords mocks the Kinesis GetRecords operation with concurrency tracking
+func (mk *MockKinesis) GetRecords(ctx context.Context, input *kinesis.GetRecordsInput, optFns ...func(*kinesis.Options)) (*kinesis.GetRecordsOutput, error) {
+	// Track call start
+	mk.mu.Lock()
+	mk.activeCalls++
+	if mk.activeCalls > mk.maxConcurrent {
+		mk.maxConcurrent = mk.activeCalls
+	}
+	mk.totalCalls++
+	delay := mk.delay
+	shouldError := mk.shouldError
+	errorTrigger := mk.errorTriggerShard
+	useGenericError := mk.useGenericError
+	mk.mu.Unlock()
+
+	// Extract shard ID from iterator (simplified)
+	iterator := aws.ToString(input.ShardIterator)
+	var shardID string
+	if len(iterator) > 5 && iterator[:5] == "iter-" {
+		// Extract shard ID from iterator format "iter-{shardID}-{seq}"
+		parts := iterator[5:]                           // Remove "iter-" prefix
+		if dashIndex := len(parts) - 2; dashIndex > 0 { // Find last dash
+			shardID = parts[:dashIndex]
+		}
+	}
+
+	// Ensure we decrement active calls when done
+	defer func() {
+		mk.mu.Lock()
+		mk.activeCalls--
+		mk.mu.Unlock()
+	}()
+
+	// Apply artificial delay if configured
+	if delay > 0 {
+		time.Sleep(delay)
+	}
+
+	// Check for configured errors
+	if shouldError && shardID == errorTrigger {
+		mk.mu.Lock()
+		if useGenericError {
+			mk.recordCall("GetRecords", shardID, fmt.Errorf("simulated kinesis error"))
+			mk.mu.Unlock()
+			return nil, fmt.Errorf("simulated kinesis error")
+		} else {
+			mk.recordCall("GetRecords", shardID, &types.ExpiredIteratorException{})
+			mk.mu.Unlock()
+			return nil, &types.ExpiredIteratorException{Message: aws.String("Iterator expired")}
+		}
+	}
+
+	mk.mu.Lock()
+	defer mk.mu.Unlock()
+
+	mk.recordCall("GetRecords", shardID, nil)
+
+	shard, exists := mk.shards[shardID]
+	if !exists {
+		return &kinesis.GetRecordsOutput{
+			Records:            []types.Record{},
+			NextShardIterator:  nil,
+			MillisBehindLatest: aws.Int64(0),
+		}, nil
+	}
+
+	// Return some records and update iterator
+	var records []types.Record
+	if len(shard.records) > 0 && !shard.closed {
+		// Return first few records
+		recordCount := len(shard.records)
+		if recordCount > 3 {
+			recordCount = 3 // Return max 3 records per call
+		}
+		records = shard.records[:recordCount]
+		shard.records = shard.records[recordCount:]
+	}
+
+	var nextIterator *string
+	if len(shard.records) > 0 && !shard.closed {
+		nextIterator = &shard.nextIterator
+		// Update iterator for next call
+		shard.iterator = shard.nextIterator
+		shard.nextIterator = shard.nextIterator + "-next"
+	} else {
+		// End of shard
+		nextIterator = nil
+	}
+
+	return &kinesis.GetRecordsOutput{
+		Records:            records,
+		NextShardIterator:  nextIterator,
+		MillisBehindLatest: aws.Int64(100),
+	}, nil
+}
+
+// DescribeStream mocks the Kinesis DescribeStream operation
+func (mk *MockKinesis) DescribeStream(ctx context.Context, input *kinesis.DescribeStreamInput, optFns ...func(*kinesis.Options)) (*kinesis.DescribeStreamOutput, error) {
+	mk.mu.Lock()
+	defer mk.mu.Unlock()
+
+	mk.recordCall("DescribeStream", "", nil)
+
+	var shards []types.Shard
+	for shardID := range mk.shards {
+		shards = append(shards, types.Shard{
+			ShardId: aws.String(shardID),
+			HashKeyRange: &types.HashKeyRange{
+				StartingHashKey: aws.String("0"),
+				EndingHashKey:   aws.String("1000"),
+			},
+			SequenceNumberRange: &types.SequenceNumberRange{
+				StartingSequenceNumber: aws.String("0"),
+			},
+		})
+	}
+
+	return &kinesis.DescribeStreamOutput{
+		StreamDescription: &types.StreamDescription{
+			StreamName:   input.StreamName,
+			StreamStatus: types.StreamStatus(mk.streamStatus),
+			Shards:       shards,
+		},
+	}, nil
+}
+
+// Implement other required methods as no-ops for interface compliance
+
+func (mk *MockKinesis) CreateStream(ctx context.Context, input *kinesis.CreateStreamInput, optFns ...func(*kinesis.Options)) (*kinesis.CreateStreamOutput, error) {
+	return &kinesis.CreateStreamOutput{}, nil
+}
+
+func (mk *MockKinesis) DeleteStream(ctx context.Context, input *kinesis.DeleteStreamInput, optFns ...func(*kinesis.Options)) (*kinesis.DeleteStreamOutput, error) {
+	return &kinesis.DeleteStreamOutput{}, nil
+}
+
+func (mk *MockKinesis) PutRecords(ctx context.Context, input *kinesis.PutRecordsInput, optFns ...func(*kinesis.Options)) (*kinesis.PutRecordsOutput, error) {
+	return &kinesis.PutRecordsOutput{
+		FailedRecordCount: aws.Int32(0),
+	}, nil
+}
+
+func (mk *MockKinesis) MergeShards(ctx context.Context, input *kinesis.MergeShardsInput, optFns ...func(*kinesis.Options)) (*kinesis.MergeShardsOutput, error) {
+	return &kinesis.MergeShardsOutput{}, nil
+}

--- a/noopstatreceiver.go
+++ b/noopstatreceiver.go
@@ -17,3 +17,9 @@ func (*NoopStatReceiver) EventToClient(inserted, retrieved time.Time) {}
 
 // EventsFromKinesis implementation that doesn't do anything
 func (*NoopStatReceiver) EventsFromKinesis(num int, shardID string, lag time.Duration) {}
+
+// RecordsInMemory implementation that doesn't do anything
+func (*NoopStatReceiver) RecordsInMemory(count int64) {}
+
+// RecordsInMemoryBytes implementation that doesn't do anything
+func (*NoopStatReceiver) RecordsInMemoryBytes(bytes int64) {}

--- a/shard_consumer.go
+++ b/shard_consumer.go
@@ -16,6 +16,16 @@ import (
 	smithy "github.com/aws/smithy-go"
 )
 
+// batchProcessResult represents the flow control decision from processing a batch of records
+type batchProcessResult int
+
+const (
+	batchSuccess  batchProcessResult = iota // continue normal processing
+	batchContinue                           // equivalent to continue mainloop
+	batchBreak                              // equivalent to break mainloop
+	batchError                              // error occurred, exit function
+)
+
 // getShardIterator gets a shard iterator after the last sequence number we read or at the start of the stream
 func getShardIterator(k kinsumeriface.KinesisAPI, streamName string, shardID string, sequenceNumber string, iteratorStartTimestamp *time.Time) (string, error) {
 	shardIteratorType := ktypes.ShardIteratorTypeAfterSequenceNumber
@@ -96,6 +106,107 @@ func (k *Kinsumer) captureShard(shardID string) (*checkpointer, error) {
 		case <-time.After(k.config.throttleDelay):
 		}
 	}
+}
+
+// processRecordsBatch handles getting and processing a batch of records with automatic semaphore management
+func (k *Kinsumer) processRecordsBatch(iterator string, shardID string, checkpointer *checkpointer, lastSeqToCheckp *string, lastSeqNum *string, commitTicker *time.Ticker) (nextIterator string, result batchProcessResult, err error) {
+	// Acquire semaphore to limit concurrent shard record fetching
+	if k.shardSemaphore != nil {
+		k.shardSemaphore <- struct{}{} // May block if limit reached
+	}
+
+	// Ensure semaphore is released regardless of how this function exits
+	defer func() {
+		if k.shardSemaphore != nil {
+			<-k.shardSemaphore
+		}
+	}()
+
+	// Get records from kinesis
+	records, next, lag, err := getRecords(k.kinesis, iterator, k.config.getRecordsLimit)
+
+	if err != nil {
+		var ae smithy.APIError
+		if errors.As(err, &ae) {
+			origErrStr := fmt.Sprintf("(%s) ", ae)
+			k.config.logger.Log("Got error: %s %s %s", ae.ErrorCode(), ae.ErrorMessage(), origErrStr)
+
+			var eie *ktypes.ExpiredIteratorException
+			if errors.As(err, &eie) {
+				k.config.logger.Log("Got error: %s %s %s", eie.ErrorCode(), eie.ErrorMessage(), origErrStr)
+				newIterator, ierr := getShardIterator(k.kinesis, k.streamName, shardID, *lastSeqToCheckp, nil)
+				if ierr != nil {
+					return "", batchError, fmt.Errorf("getShardIterator after expired iterator: %w", ierr)
+				}
+				// retry infinitely after expired iterator is renewed successfully
+				return newIterator, batchContinue, nil
+			}
+		}
+		return "", batchError, fmt.Errorf("getRecords: %w", err)
+	}
+
+	// Put all the records we got onto the channel
+	k.config.stats.EventsFromKinesis(len(records), shardID, lag)
+	k.metricsManager.updateMetric(RecordsIncrement, int64(len(records)))
+
+	// Calculate total payload bytes in the batch
+	totalBytes := int64(0)
+	for _, record := range records {
+		totalBytes += int64(len(record.Data))
+	}
+	k.metricsManager.updateMetric(BytesIncrement, totalBytes)
+
+	// Track records for cleanup in case of early return
+	recordsToCleanup := int64(len(records))
+	bytesToCleanup := totalBytes
+	defer func() {
+		// Decrement any records that weren't successfully processed
+		if recordsToCleanup > 0 {
+			k.metricsManager.updateMetric(RecordsDecrement, recordsToCleanup)
+		}
+		if bytesToCleanup > 0 {
+			k.metricsManager.updateMetric(BytesDecrement, bytesToCleanup)
+		}
+	}()
+
+	if len(records) > 0 {
+		retrievedAt := time.Now()
+		for _, record := range records {
+			// Loop until we stop or the record is consumed, checkpointing if necessary.
+			recordPayloadBytes := int64(len(record.Data))
+		RecordLoop:
+			for {
+				select {
+				case <-commitTicker.C:
+					finishCommitted, err := checkpointer.commit(k.config.commitFrequency)
+					if err != nil {
+						return "", batchError, fmt.Errorf("checkpointer.commit: %w", err)
+					}
+					if finishCommitted {
+						return "", batchSuccess, nil
+					}
+				case <-k.stop:
+					return "", batchBreak, nil
+				case k.records <- &consumedRecord{
+					record:       &record,
+					checkpointer: checkpointer,
+					retrievedAt:  retrievedAt,
+					payloadBytes: recordPayloadBytes,
+				}:
+					recordsToCleanup--                         // Record successfully sent to channel
+					bytesToCleanup -= recordPayloadBytes       // Decrement bytes for successfully sent record
+					checkpointer.lastRecordPassed = time.Now() // Mark the time so we don't retain shards when we're too slow to do so
+					*lastSeqToCheckp = aws.ToString(record.SequenceNumber)
+					break RecordLoop
+				}
+			}
+		}
+
+		// Update the last sequence number we saw, in case we reached the end of the stream.
+		*lastSeqNum = aws.ToString(records[len(records)-1].SequenceNumber)
+	}
+
+	return next, batchSuccess, nil
 }
 
 // consume is a blocking call that captures then consumes the given shard in a loop.
@@ -183,113 +294,26 @@ mainloop:
 			continue mainloop
 		}
 
-		// Acquire semaphore to limit concurrent shard record fetching
-		if k.shardSemaphore != nil {
-			k.shardSemaphore <- struct{}{} // May block if limit reached
-		}
-
-		// Helper function for safe semaphore release
-		releaseSemaphore := func() {
-			if k.shardSemaphore != nil {
-				<-k.shardSemaphore
-			}
-		}
-
-		// Get records from kinesis
-		records, next, lag, err := getRecords(k.kinesis, iterator, k.config.getRecordsLimit)
-
+		// Process records batch with automatic semaphore management
+		nextIterator, result, err := k.processRecordsBatch(iterator, shardID, checkpointer, &lastSeqToCheckp, &lastSeqNum, commitTicker)
 		if err != nil {
-			var ae smithy.APIError
-			if errors.As(err, &ae) {
-				origErrStr := fmt.Sprintf("(%s) ", ae)
-				k.config.logger.Log("Got error: %s %s %s", ae.ErrorCode(), ae.ErrorMessage(), origErrStr)
-
-				var eie *ktypes.ExpiredIteratorException
-				if errors.As(err, &eie) {
-					k.config.logger.Log("Got error: %s %s %s", eie.ErrorCode(), eie.ErrorMessage(), origErrStr)
-					newIterator, ierr := getShardIterator(k.kinesis, k.streamName, shardID, lastSeqToCheckp, nil)
-					if ierr != nil {
-						releaseSemaphore()
-						k.shardErrors <- shardConsumerError{shardID: shardID, action: "getShardIterator", err: err}
-						return
-					}
-					iterator = newIterator
-
-					// retry infinitely after expired iterator is renewed successfully
-					releaseSemaphore()
-					continue mainloop
-				}
-			}
-			releaseSemaphore()
-			k.shardErrors <- shardConsumerError{shardID: shardID, action: "getRecords", err: err}
+			k.shardErrors <- shardConsumerError{shardID: shardID, action: "processRecordsBatch", err: err}
 			return
 		}
 
-		// Put all the records we got onto the channel
-		k.config.stats.EventsFromKinesis(len(records), shardID, lag)
-		k.metricsManager.updateMetric(RecordsIncrement, int64(len(records)))
-
-		// Calculate total payload bytes in the batch
-		totalBytes := int64(0)
-		for _, record := range records {
-			totalBytes += int64(len(record.Data))
-		}
-		k.metricsManager.updateMetric(BytesIncrement, totalBytes)
-
-		// Track records for cleanup in case of early return
-		recordsToCleanup := int64(len(records))
-		bytesToCleanup := totalBytes
-		defer func() {
-			// Decrement any records that weren't successfully processed
-			if recordsToCleanup > 0 {
-				k.metricsManager.updateMetric(RecordsDecrement, recordsToCleanup)
-			}
-			if bytesToCleanup > 0 {
-				k.metricsManager.updateMetric(BytesDecrement, bytesToCleanup)
-			}
-		}()
-
-		if len(records) > 0 {
-			retrievedAt := time.Now()
-			for _, record := range records {
-				// Loop until we stop or the record is consumed, checkpointing if necessary.
-				recordPayloadBytes := int64(len(record.Data))
-			RecordLoop:
-				for {
-					select {
-					case <-commitTicker.C:
-						finishCommitted, err := checkpointer.commit(k.config.commitFrequency)
-						if err != nil {
-							k.shardErrors <- shardConsumerError{shardID: shardID, action: "checkpointer.commit", err: err}
-							return
-						}
-						if finishCommitted {
-							return
-						}
-					case <-k.stop:
-						break mainloop
-					case k.records <- &consumedRecord{
-						record:       &record,
-						checkpointer: checkpointer,
-						retrievedAt:  retrievedAt,
-						payloadBytes: recordPayloadBytes,
-					}:
-						recordsToCleanup--                         // Record successfully sent to channel
-						bytesToCleanup -= recordPayloadBytes       // Decrement bytes for successfully sent record
-						checkpointer.lastRecordPassed = time.Now() // Mark the time so we don't retain shards when we're too slow to do so
-						lastSeqToCheckp = aws.ToString(record.SequenceNumber)
-						break RecordLoop
-					}
-				}
-			}
-
-			// Update the last sequence number we saw, in case we reached the end of the stream.
-			lastSeqNum = aws.ToString(records[len(records)-1].SequenceNumber)
+		// Handle flow control based on batch processing result
+		switch result {
+		case batchBreak:
+			break mainloop
+		case batchContinue:
+			continue mainloop
+		case batchError:
+			return // Error already sent to shardErrors channel above
+		case batchSuccess:
+			// Continue to next iteration normally
 		}
 
-		// Release semaphore after successfully processing all records from this batch
-		releaseSemaphore()
-		iterator = next
+		iterator = nextIterator
 	}
 	// Handle checkpointer updates which occur after a stop request comes in (whose originating records were before)
 

--- a/shard_consumer.go
+++ b/shard_consumer.go
@@ -15,12 +15,6 @@ import (
 	smithy "github.com/aws/smithy-go"
 )
 
-const (
-	// getRecordsLimit is the max number of records in a single request. This effectively limits the
-	// total processing speed to getRecordsLimit*5/n where n is the number of parallel clients trying
-	// to consume from the same kinesis stream
-	getRecordsLimit = 10000 // 10,000 is the max according to the docs
-)
 
 // getShardIterator gets a shard iterator after the last sequence number we read or at the start of the stream
 func getShardIterator(k kinsumeriface.KinesisAPI, streamName string, shardID string, sequenceNumber string, iteratorStartTimestamp *time.Time) (string, error) {
@@ -54,9 +48,9 @@ func getShardIterator(k kinsumeriface.KinesisAPI, streamName string, shardID str
 }
 
 // getRecords returns the next records and shard iterator from the given shard iterator
-func getRecords(k kinsumeriface.KinesisAPI, iterator string) (records []ktypes.Record, nextIterator string, lag time.Duration, err error) {
+func getRecords(k kinsumeriface.KinesisAPI, iterator string, limit int) (records []ktypes.Record, nextIterator string, lag time.Duration, err error) {
 	params := &kinesis.GetRecordsInput{
-		Limit:         aws.Int32(getRecordsLimit),
+		Limit:         aws.Int32(int32(limit)),
 		ShardIterator: aws.String(iterator),
 	}
 
@@ -190,7 +184,7 @@ mainloop:
 		}
 
 		// Get records from kinesis
-		records, next, lag, err := getRecords(k.kinesis, iterator)
+		records, next, lag, err := getRecords(k.kinesis, iterator, k.config.getRecordsLimit)
 
 		if err != nil {
 			var ae smithy.APIError

--- a/shard_consumer.go
+++ b/shard_consumer.go
@@ -6,15 +6,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/twitchscience/kinsumer/kinsumeriface"
 	"time"
+
+	"github.com/twitchscience/kinsumer/kinsumeriface"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis"
 	ktypes "github.com/aws/aws-sdk-go-v2/service/kinesis/types"
 	smithy "github.com/aws/smithy-go"
 )
-
 
 // getShardIterator gets a shard iterator after the last sequence number we read or at the start of the stream
 func getShardIterator(k kinsumeriface.KinesisAPI, streamName string, shardID string, sequenceNumber string, iteratorStartTimestamp *time.Time) (string, error) {
@@ -227,11 +227,34 @@ mainloop:
 
 		// Put all the records we got onto the channel
 		k.config.stats.EventsFromKinesis(len(records), shardID, lag)
+		k.metricsManager.updateMetric(RecordsIncrement, int64(len(records)))
+
+		// Calculate total payload bytes in the batch
+		totalBytes := int64(0)
+		for _, record := range records {
+			totalBytes += int64(len(record.Data))
+		}
+		k.metricsManager.updateMetric(BytesIncrement, totalBytes)
+
+		// Track records for cleanup in case of early return
+		recordsToCleanup := int64(len(records))
+		bytesToCleanup := totalBytes
+		defer func() {
+			// Decrement any records that weren't successfully processed
+			if recordsToCleanup > 0 {
+				k.metricsManager.updateMetric(RecordsDecrement, recordsToCleanup)
+			}
+			if bytesToCleanup > 0 {
+				k.metricsManager.updateMetric(BytesDecrement, bytesToCleanup)
+			}
+		}()
+
 		if len(records) > 0 {
 			retrievedAt := time.Now()
 			for _, record := range records {
-			RecordLoop:
 				// Loop until we stop or the record is consumed, checkpointing if necessary.
+				recordPayloadBytes := int64(len(record.Data))
+			RecordLoop:
 				for {
 					select {
 					case <-commitTicker.C:
@@ -249,7 +272,10 @@ mainloop:
 						record:       &record,
 						checkpointer: checkpointer,
 						retrievedAt:  retrievedAt,
+						payloadBytes: recordPayloadBytes,
 					}:
+						recordsToCleanup--                         // Record successfully sent to channel
+						bytesToCleanup -= recordPayloadBytes       // Decrement bytes for successfully sent record
 						checkpointer.lastRecordPassed = time.Now() // Mark the time so we don't retain shards when we're too slow to do so
 						lastSeqToCheckp = aws.ToString(record.SequenceNumber)
 						break RecordLoop
@@ -260,7 +286,7 @@ mainloop:
 			// Update the last sequence number we saw, in case we reached the end of the stream.
 			lastSeqNum = aws.ToString(records[len(records)-1].SequenceNumber)
 		}
-		
+
 		// Release semaphore after successfully processing all records from this batch
 		releaseSemaphore()
 		iterator = next

--- a/shard_consumer.go
+++ b/shard_consumer.go
@@ -183,6 +183,18 @@ mainloop:
 			continue mainloop
 		}
 
+		// Acquire semaphore to limit concurrent shard record fetching
+		if k.shardSemaphore != nil {
+			k.shardSemaphore <- struct{}{} // May block if limit reached
+		}
+
+		// Helper function for safe semaphore release
+		releaseSemaphore := func() {
+			if k.shardSemaphore != nil {
+				<-k.shardSemaphore
+			}
+		}
+
 		// Get records from kinesis
 		records, next, lag, err := getRecords(k.kinesis, iterator, k.config.getRecordsLimit)
 
@@ -197,15 +209,18 @@ mainloop:
 					k.config.logger.Log("Got error: %s %s %s", eie.ErrorCode(), eie.ErrorMessage(), origErrStr)
 					newIterator, ierr := getShardIterator(k.kinesis, k.streamName, shardID, lastSeqToCheckp, nil)
 					if ierr != nil {
+						releaseSemaphore()
 						k.shardErrors <- shardConsumerError{shardID: shardID, action: "getShardIterator", err: err}
 						return
 					}
 					iterator = newIterator
 
 					// retry infinitely after expired iterator is renewed successfully
+					releaseSemaphore()
 					continue mainloop
 				}
 			}
+			releaseSemaphore()
 			k.shardErrors <- shardConsumerError{shardID: shardID, action: "getRecords", err: err}
 			return
 		}
@@ -245,6 +260,9 @@ mainloop:
 			// Update the last sequence number we saw, in case we reached the end of the stream.
 			lastSeqNum = aws.ToString(records[len(records)-1].SequenceNumber)
 		}
+		
+		// Release semaphore after successfully processing all records from this batch
+		releaseSemaphore()
 		iterator = next
 	}
 	// Handle checkpointer updates which occur after a stop request comes in (whose originating records were before)

--- a/shard_consumer_test.go
+++ b/shard_consumer_test.go
@@ -2,13 +2,17 @@ package kinsumer
 
 import (
 	"fmt"
-	"github.com/twitchscience/kinsumer/kinsumeriface"
 	"strconv"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/twitchscience/kinsumer/kinsumeriface"
+	"github.com/twitchscience/kinsumer/mocks"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	dbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis/types"
 
@@ -1001,4 +1005,396 @@ func TestGetDupesFromSlice(t *testing.T) {
 
 	dupes2 := getDupesFromSlice(sliceWithoutDupes)
 	assert.Equal(t, 0, len(dupes2))
+}
+
+// TestMaxConcurrentShards tests the maxConcurrentShards feature using MockKinesis
+// to verify that semaphore properly limits concurrent shard record fetching
+func TestMaxConcurrentShards(t *testing.T) {
+
+	// Test setup: Create 5 mock shards with concurrency limit of 2
+	shardIDs := []string{"shard-001", "shard-002", "shard-003", "shard-004", "shard-005"}
+	mockKinesis := mocks.NewMockKinesis(shardIDs)
+
+	// Create MockDynamo with proper table names (applicationName + "_" + table_type)
+	mockDynamo := mocks.NewMockDynamo([]string{"test-app_checkpoints", "test-app_clients", "test-app_metadata"})
+
+	// Pre-populate checkpoint records for each shard (unowned so they can be captured)
+	for _, shardID := range shardIDs {
+		checkpointItem := map[string]dbtypes.AttributeValue{
+			"Shard":          &dbtypes.AttributeValueMemberS{Value: shardID},
+			"SequenceNumber": &dbtypes.AttributeValueMemberS{Value: ""},  // Start from beginning
+			"LastUpdate":     &dbtypes.AttributeValueMemberN{Value: "0"}, // Old timestamp = unowned
+			// OwnerName and OwnerID are nil (unowned)
+			// Finished is nil (active shard)
+		}
+		_, err := mockDynamo.PutItem(t.Context(), &dynamodb.PutItemInput{
+			TableName: aws.String("test-app_checkpoints"),
+			Item:      checkpointItem,
+		})
+		require.NoError(t, err, "Failed to populate checkpoint for shard %s", shardID)
+	}
+
+	// Set a delay to make concurrent behavior observable
+	mockKinesis.SetDelay(100 * time.Millisecond)
+
+	// Test with concurrency limit
+	config := NewConfig().
+		WithBufferSize(1000).
+		WithShardCheckFrequency(500 * time.Millisecond).
+		WithLeaderActionFrequency(500 * time.Millisecond).
+		WithCommitFrequency(100 * time.Millisecond).
+		WithMaxConcurrentShards(2) // Limit to 2 concurrent shards
+
+	kinsumer, err := NewWithInterfaces(mockKinesis, mockDynamo, "test-stream", "test-app", "test-client", "", config)
+	require.NoError(t, err, "Failed to create kinsumer with concurrency limit")
+
+	// Initialize channels that consume() expects to exist
+	kinsumer.stop = make(chan struct{})
+	kinsumer.shardErrors = make(chan shardConsumerError, 10)
+	kinsumer.records = make(chan *consumedRecord, 1000)
+
+	// Manually start consuming each shard
+	var wg sync.WaitGroup
+	for _, shardID := range shardIDs {
+		wg.Add(1)
+		go func(shard string) {
+			defer wg.Done()
+			kinsumer.waitGroup.Add(1) // consume() expects this
+			kinsumer.consume(shard)
+		}(shardID)
+	}
+
+	// Wait a moment for consumers to start up and begin processing
+	time.Sleep(50 * time.Millisecond)
+
+	// Verify that we reach the expected concurrency level (2)
+	success := mockKinesis.WaitForConcurrentCalls(2, 2*time.Second)
+	assert.True(t, success, "Expected to reach 2 concurrent calls")
+
+	// Let it run for a bit to collect data
+	time.Sleep(500 * time.Millisecond)
+
+	// Verify concurrency never exceeded the limit
+	maxConcurrent := mockKinesis.GetMaxConcurrentCalls()
+	assert.LessOrEqual(t, maxConcurrent, 2, "Concurrent calls should never exceed limit of 2, got %d", maxConcurrent)
+
+	// Verify we got some calls (processing is happening)
+	totalCalls := mockKinesis.GetTotalCalls()
+	assert.Greater(t, totalCalls, 5, "Should have made multiple GetRecords calls, got %d", totalCalls)
+
+	// Stop consumers
+	close(kinsumer.stop)
+
+	// Wait for all goroutines to finish
+	wg.Wait()
+
+	t.Logf("Max concurrent calls observed: %d (limit was 2)", maxConcurrent)
+	t.Logf("Total GetRecords calls made: %d", totalCalls)
+}
+
+// TestMaxConcurrentShardsUnlimited tests that maxConcurrentShards=0 means unlimited
+func TestMaxConcurrentShardsUnlimited(t *testing.T) {
+
+	// Test setup: Create 5 mock shards with no concurrency limit
+	shardIDs := []string{"shard-001", "shard-002", "shard-003", "shard-004", "shard-005"}
+	mockKinesis := mocks.NewMockKinesis(shardIDs)
+
+	// Create MockDynamo with proper table names (applicationName + "_" + table_type)
+	mockDynamo := mocks.NewMockDynamo([]string{"test-app_checkpoints", "test-app_clients", "test-app_metadata"})
+
+	// Pre-populate checkpoint records for each shard (unowned so they can be captured)
+	for _, shardID := range shardIDs {
+		checkpointItem := map[string]dbtypes.AttributeValue{
+			"Shard":          &dbtypes.AttributeValueMemberS{Value: shardID},
+			"SequenceNumber": &dbtypes.AttributeValueMemberS{Value: ""},  // Start from beginning
+			"LastUpdate":     &dbtypes.AttributeValueMemberN{Value: "0"}, // Old timestamp = unowned
+			// OwnerName and OwnerID are nil (unowned)
+			// Finished is nil (active shard)
+		}
+		_, err := mockDynamo.PutItem(t.Context(), &dynamodb.PutItemInput{
+			TableName: aws.String("test-app_checkpoints"),
+			Item:      checkpointItem,
+		})
+		require.NoError(t, err, "Failed to populate checkpoint for shard %s", shardID)
+	}
+
+	// Set a delay to make concurrent behavior observable
+	mockKinesis.SetDelay(100 * time.Millisecond)
+
+	// Test with unlimited concurrency (default)
+	config := NewConfig().
+		WithBufferSize(1000).
+		WithShardCheckFrequency(500 * time.Millisecond).
+		WithLeaderActionFrequency(500 * time.Millisecond).
+		WithCommitFrequency(100 * time.Millisecond)
+		// maxConcurrentShards defaults to 0 (unlimited)
+
+	kinsumer, err := NewWithInterfaces(mockKinesis, mockDynamo, "test-stream", "test-app", "test-client", "", config)
+	require.NoError(t, err, "Failed to create kinsumer without concurrency limit")
+
+	// Initialize channels that consume() expects to exist
+	kinsumer.stop = make(chan struct{})
+	kinsumer.shardErrors = make(chan shardConsumerError, 10)
+	kinsumer.records = make(chan *consumedRecord, 1000)
+
+	// Manually start consuming each shard
+	var wg sync.WaitGroup
+	for _, shardID := range shardIDs {
+		wg.Add(1)
+		go func(shard string) {
+			defer wg.Done()
+			kinsumer.waitGroup.Add(1) // consume() expects this
+			kinsumer.consume(shard)
+		}(shardID)
+	}
+
+	// Wait a moment for consumers to start up
+	time.Sleep(50 * time.Millisecond)
+
+	// With unlimited concurrency, we should be able to reach all 5 concurrent calls
+	success := mockKinesis.WaitForConcurrentCalls(5, 2*time.Second)
+	assert.True(t, success, "Expected to reach 5 concurrent calls with unlimited setting")
+
+	// Let it run for a bit
+	time.Sleep(300 * time.Millisecond)
+
+	// Verify we can process all shards concurrently
+	maxConcurrent := mockKinesis.GetMaxConcurrentCalls()
+	assert.Equal(t, 5, maxConcurrent, "Should allow all 5 shards to process concurrently, got %d", maxConcurrent)
+
+	// Stop consumers
+	close(kinsumer.stop)
+
+	// Wait for all goroutines to finish
+	wg.Wait()
+
+	t.Logf("Max concurrent calls observed: %d (should be 5 with unlimited)", maxConcurrent)
+	t.Logf("Total GetRecords calls made: %d", mockKinesis.GetTotalCalls())
+}
+
+// TestProcessRecordsBatchSemaphoreAllPaths is a focused unit test that directly tests
+// the semaphore behavior in processRecordsBatch() for all possible code paths
+func TestProcessRecordsBatchSemaphoreAllPaths(t *testing.T) {
+
+	// Configuration for checkpointer setup
+	type checkpointerConfig struct {
+		tableName           string
+		finished            bool
+		finalSequenceNumber string
+	}
+
+	// Helper to inspect semaphore state directly
+	getSemaphoreUsed := func(sem chan struct{}) int {
+		if sem == nil {
+			return 0
+		}
+		return len(sem)
+	}
+
+	// Helper to create kinsumer with test-specific configuration
+	createTestKinsumer := func(semaphore chan struct{}, stopChan chan struct{}, recordsChan chan *consumedRecord) *Kinsumer {
+		return &Kinsumer{
+			kinesis:        nil, // Will be set by caller
+			shardSemaphore: semaphore,
+			records:        recordsChan,
+			config:         NewConfig().WithMaxConcurrentShards(1),
+			metricsManager: newMetricsManager(&DefaultLogger{}),
+			stop:           stopChan,
+		}
+	}
+
+	// Helper to create checkpointer and ticker with test-specific configuration
+	createCheckpointerAndTicker := func(config checkpointerConfig, tickerInterval time.Duration) (*checkpointer, *time.Ticker) {
+		mockDynamo := mocks.NewMockDynamo([]string{"test-table"})
+
+		checkpointer := &checkpointer{
+			sequenceNumber:      "",
+			shardID:             "test-shard",
+			tableName:           config.tableName,
+			dynamodb:            mockDynamo,
+			ownerName:           "test-owner",
+			ownerID:             "test-owner-id",
+			stats:               &NoopStatReceiver{},
+			lastUpdate:          time.Now().UnixNano(),
+			finished:            config.finished,
+			finalSequenceNumber: config.finalSequenceNumber,
+		}
+
+		ticker := time.NewTicker(tickerInterval)
+
+		return checkpointer, ticker
+	}
+
+	// Test cases covering all processRecordsBatch code paths
+	testCases := []struct {
+		name               string
+		setupMock          func(*mocks.MockKinesis)
+		expectError        bool
+		description        string
+		stopChan           chan struct{}
+		recordsChan        chan *consumedRecord
+		tickerInterval     time.Duration
+		checkpointerConfig checkpointerConfig
+		runStopGoroutine   bool
+	}{
+		{
+			name:               "normal_success",
+			setupMock:          func(mk *mocks.MockKinesis) {}, // Default behavior - returns records
+			expectError:        false,
+			description:        "Normal processing should acquire and release semaphore",
+			stopChan:           nil,                             // No stop channel needed
+			recordsChan:        make(chan *consumedRecord, 100), // Buffered - won't block
+			tickerInterval:     100 * time.Millisecond,
+			checkpointerConfig: checkpointerConfig{tableName: "test-table", finished: false, finalSequenceNumber: ""},
+			runStopGoroutine:   false,
+		},
+		{
+			name: "getRecords_error",
+			setupMock: func(mk *mocks.MockKinesis) {
+				mk.SetGenericError("test-shard") // Will return generic error (not ExpiredIteratorException)
+			},
+			expectError:        true,
+			description:        "GetRecords error should still release semaphore via defer",
+			stopChan:           nil,                             // No stop channel needed
+			recordsChan:        make(chan *consumedRecord, 100), // Buffered - won't block
+			tickerInterval:     100 * time.Millisecond,
+			checkpointerConfig: checkpointerConfig{tableName: "test-table", finished: false, finalSequenceNumber: ""},
+			runStopGoroutine:   false,
+		},
+		{
+			name: "no_records_returned",
+			setupMock: func(mk *mocks.MockKinesis) {
+				mk.SetEmptyRecords("test-shard") // Return empty records array
+			},
+			expectError:        false,
+			description:        "No records returned should still release semaphore",
+			stopChan:           nil,                             // No stop channel needed
+			recordsChan:        make(chan *consumedRecord, 100), // Buffered - won't block
+			tickerInterval:     100 * time.Millisecond,
+			checkpointerConfig: checkpointerConfig{tableName: "test-table", finished: false, finalSequenceNumber: ""},
+			runStopGoroutine:   false,
+		},
+		{
+			name: "expired_iterator_getShardIterator_succeeds",
+			setupMock: func(mk *mocks.MockKinesis) {
+				mk.SetError("test-shard", true) // Return ExpiredIteratorException, but GetShardIterator will succeed
+			},
+			expectError:        false, // batchContinue, not error
+			description:        "ExpiredIteratorException with successful getShardIterator should release semaphore",
+			stopChan:           nil,                             // No stop channel needed
+			recordsChan:        make(chan *consumedRecord, 100), // Buffered - won't block
+			tickerInterval:     100 * time.Millisecond,
+			checkpointerConfig: checkpointerConfig{tableName: "test-table", finished: false, finalSequenceNumber: ""},
+			runStopGoroutine:   false,
+		},
+		{
+			name: "expired_iterator_getShardIterator_fails",
+			setupMock: func(mk *mocks.MockKinesis) {
+				mk.SetBothGetRecordsAndGetShardIteratorErrors("test-shard") // Both GetRecords and GetShardIterator fail
+			},
+			expectError:        true, // batchError when getShardIterator fails
+			description:        "ExpiredIteratorException with failed getShardIterator should release semaphore",
+			stopChan:           nil,                             // No stop channel needed
+			recordsChan:        make(chan *consumedRecord, 100), // Buffered - won't block
+			tickerInterval:     100 * time.Millisecond,
+			checkpointerConfig: checkpointerConfig{tableName: "test-table", finished: false, finalSequenceNumber: ""},
+			runStopGoroutine:   false,
+		},
+		{
+			name: "stop_signal_received",
+			setupMock: func(mk *mocks.MockKinesis) {
+				// Keep default behavior - return records so we enter the RecordLoop
+			},
+			expectError:        false, // batchBreak, not error
+			description:        "Stop signal during record processing should release semaphore",
+			stopChan:           make(chan struct{}),             // Need stop channel
+			recordsChan:        make(chan *consumedRecord, 100), // Buffered - won't block
+			tickerInterval:     100 * time.Millisecond,
+			checkpointerConfig: checkpointerConfig{tableName: "test-table", finished: false, finalSequenceNumber: ""},
+			runStopGoroutine:   true,
+		},
+		{
+			name: "commit_ticker_fires_commit_fails",
+			setupMock: func(mk *mocks.MockKinesis) {
+				// Keep default behavior - return records so we enter the RecordLoop
+			},
+			expectError:        true, // batchError when commit fails
+			description:        "Commit ticker fires and commit fails should release semaphore",
+			stopChan:           nil,                                                                                      // No stop channel needed
+			recordsChan:        make(chan *consumedRecord),                                                               // Unbuffered - will block record sending to force commit ticker
+			tickerInterval:     1 * time.Millisecond,                                                                     // Fast ticker
+			checkpointerConfig: checkpointerConfig{tableName: "error-trigger", finished: false, finalSequenceNumber: ""}, // Trigger error
+			runStopGoroutine:   false,
+		},
+		{
+			name: "commit_ticker_fires_commit_succeeds_finished",
+			setupMock: func(mk *mocks.MockKinesis) {
+				// Keep default behavior - return records so we enter the RecordLoop
+			},
+			expectError:        false, // batchSuccess when commit succeeds with finishCommitted=true
+			description:        "Commit ticker fires and commit succeeds with finishCommitted should release semaphore",
+			stopChan:           nil,                                                                                  // No stop channel needed
+			recordsChan:        make(chan *consumedRecord),                                                           // Unbuffered - will block record sending to force commit ticker
+			tickerInterval:     1 * time.Millisecond,                                                                 // Fast ticker
+			checkpointerConfig: checkpointerConfig{tableName: "test-table", finished: true, finalSequenceNumber: ""}, // Force finishCommitted=true
+			runStopGoroutine:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Minimal setup - only what processRecordsBatch needs
+			semaphore := make(chan struct{}, 1) // Capacity of 1 for easy verification
+			mockKinesis := mocks.NewMockKinesis([]string{"test-shard"})
+
+			// Apply test-specific mock setup
+			tc.setupMock(mockKinesis)
+
+			// Create kinsumer with test-specific configuration
+			kinsumer := createTestKinsumer(semaphore, tc.stopChan, tc.recordsChan)
+			kinsumer.kinesis = mockKinesis // Set the mock kinesis
+
+			// Create checkpointer and ticker with test-specific configuration
+			mockCheckpointer, ticker := createCheckpointerAndTicker(tc.checkpointerConfig, tc.tickerInterval)
+			defer ticker.Stop()
+
+			lastSeq := ""
+			lastSeqNum := ""
+
+			// Verify semaphore starts empty
+			before := getSemaphoreUsed(semaphore)
+			assert.Equal(t, 0, before, "Semaphore should start empty")
+
+			// For stop signal test, close the stop channel after a delay to trigger batchBreak
+			if tc.runStopGoroutine && tc.stopChan != nil {
+				go func() {
+					time.Sleep(10 * time.Millisecond) // Small delay to let processing start
+					close(tc.stopChan)
+				}()
+			}
+
+			// Call processRecordsBatch directly - this is where semaphore logic lives
+			iterator := "iter-test-shard-0" // Use format that MockKinesis expects
+			_, result, err := kinsumer.processRecordsBatch(iterator, "test-shard", mockCheckpointer, &lastSeq, &lastSeqNum, ticker)
+
+			// Verify semaphore is released regardless of success or error
+			after := getSemaphoreUsed(semaphore)
+			assert.Equal(t, 0, after, "Semaphore should be released for case: %s - %s", tc.name, tc.description)
+
+			// Verify expected error behavior
+			if tc.expectError {
+				assert.Equal(t, batchError, result, "Expected batchError result for %s", tc.name)
+				assert.Error(t, err, "Expected error for %s", tc.name)
+			} else {
+				assert.NoError(t, err, "Expected no error for %s", tc.name)
+				assert.NotEqual(t, batchError, result, "Expected non-error result for %s", tc.name)
+			}
+
+			// Verify MockKinesis saw exactly one call
+			totalCalls := mockKinesis.GetTotalCalls()
+			assert.Equal(t, 1, totalCalls, "Expected exactly 1 GetRecords call for %s", tc.name)
+
+			t.Logf("✓ %s: Semaphore properly released (before=%d, after=%d)", tc.description, before, after)
+		})
+	}
 }

--- a/statreceiver.go
+++ b/statreceiver.go
@@ -27,4 +27,61 @@ type StatReceiver interface {
 	// `shardID` ID of the shard that the records were retrieved from
 	// `lag` How far the records are from the tip of the stream.
 	EventsFromKinesis(num int, shardID string, lag time.Duration)
+
+	// RecordsInMemory is called periodically to report the current number of records
+	// that have been pulled from Kinesis and are buffered in memory, waiting to be
+	// delivered to the client.
+	// `count` Current number of records in the internal buffer
+	RecordsInMemory(count int64)
+
+	// RecordsInMemoryBytes is called periodically to report the current total bytes
+	// of record payloads that have been pulled from Kinesis and are buffered in memory,
+	// waiting to be delivered to the client.
+	// `bytes` Current total payload bytes in the internal buffer
+	RecordsInMemoryBytes(bytes int64)
+}
+
+// filteredStatReceiver wraps a StatReceiver and filters method calls based on MetricsConfig
+// This allows selective enabling/disabling of metrics at the configuration level
+type filteredStatReceiver struct {
+	underlying StatReceiver
+	config     MetricsConfig
+}
+
+// newFilteredStatReceiver creates a new filteredStatReceiver that wraps the underlying StatReceiver
+func newFilteredStatReceiver(underlying StatReceiver, config MetricsConfig) StatReceiver {
+	return &filteredStatReceiver{
+		underlying: underlying,
+		config:     config,
+	}
+}
+
+func (f *filteredStatReceiver) Checkpoint() {
+	if f.config.EnableCheckpoint {
+		f.underlying.Checkpoint()
+	}
+}
+
+func (f *filteredStatReceiver) EventToClient(inserted, retrieved time.Time) {
+	if f.config.EnableEventToClient {
+		f.underlying.EventToClient(inserted, retrieved)
+	}
+}
+
+func (f *filteredStatReceiver) EventsFromKinesis(num int, shardID string, lag time.Duration) {
+	if f.config.EnableEventsFromKinesis {
+		f.underlying.EventsFromKinesis(num, shardID, lag)
+	}
+}
+
+func (f *filteredStatReceiver) RecordsInMemory(count int64) {
+	if f.config.EnableRecordsInMemory {
+		f.underlying.RecordsInMemory(count)
+	}
+}
+
+func (f *filteredStatReceiver) RecordsInMemoryBytes(bytes int64) {
+	if f.config.EnableRecordsInMemoryBytes {
+		f.underlying.RecordsInMemoryBytes(bytes)
+	}
 }

--- a/statreceiver_test.go
+++ b/statreceiver_test.go
@@ -1,0 +1,338 @@
+// Copyright (c) 2016 Twitch Interactive
+
+package kinsumer
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStatReceiver is a StatReceiver implementation that captures all method calls
+// for testing purposes. It is thread-safe since StatReceiver methods can be called
+// from multiple goroutines.
+type TestStatReceiver struct {
+	mu                        sync.Mutex
+	recordsInMemoryCalls      []int64
+	recordsInMemoryBytesCalls []int64
+	checkpointCalls           int
+	eventToClientCalls        int
+	eventsFromKinesisCalls    []EventsFromKinesisCall
+}
+
+// EventsFromKinesisCall captures the parameters of EventsFromKinesis calls
+type EventsFromKinesisCall struct {
+	Num     int
+	ShardID string
+	Lag     time.Duration
+}
+
+// Checkpoint captures checkpoint calls
+func (t *TestStatReceiver) Checkpoint() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.checkpointCalls++
+}
+
+// EventToClient captures event to client calls
+func (t *TestStatReceiver) EventToClient(inserted, retrieved time.Time) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.eventToClientCalls++
+}
+
+// EventsFromKinesis captures events from kinesis calls
+func (t *TestStatReceiver) EventsFromKinesis(num int, shardID string, lag time.Duration) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.eventsFromKinesisCalls = append(t.eventsFromKinesisCalls, EventsFromKinesisCall{
+		Num:     num,
+		ShardID: shardID,
+		Lag:     lag,
+	})
+}
+
+// RecordsInMemory captures records in memory calls
+func (t *TestStatReceiver) RecordsInMemory(count int64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.recordsInMemoryCalls = append(t.recordsInMemoryCalls, count)
+}
+
+// RecordsInMemoryBytes captures records in memory bytes calls
+func (t *TestStatReceiver) RecordsInMemoryBytes(bytes int64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.recordsInMemoryBytesCalls = append(t.recordsInMemoryBytesCalls, bytes)
+}
+
+// Helper methods for testing
+
+// GetRecordsInMemoryCalls returns a copy of all RecordsInMemory calls
+func (t *TestStatReceiver) GetRecordsInMemoryCalls() []int64 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	calls := make([]int64, len(t.recordsInMemoryCalls))
+	copy(calls, t.recordsInMemoryCalls)
+	return calls
+}
+
+// GetRecordsInMemoryBytesCalls returns a copy of all RecordsInMemoryBytes calls
+func (t *TestStatReceiver) GetRecordsInMemoryBytesCalls() []int64 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	calls := make([]int64, len(t.recordsInMemoryBytesCalls))
+	copy(calls, t.recordsInMemoryBytesCalls)
+	return calls
+}
+
+// GetLastRecordsInMemory returns the last RecordsInMemory value, or -1 if no calls
+func (t *TestStatReceiver) GetLastRecordsInMemory() int64 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if len(t.recordsInMemoryCalls) == 0 {
+		return -1
+	}
+	return t.recordsInMemoryCalls[len(t.recordsInMemoryCalls)-1]
+}
+
+// GetLastRecordsInMemoryBytes returns the last RecordsInMemoryBytes value, or -1 if no calls
+func (t *TestStatReceiver) GetLastRecordsInMemoryBytes() int64 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if len(t.recordsInMemoryBytesCalls) == 0 {
+		return -1
+	}
+	return t.recordsInMemoryBytesCalls[len(t.recordsInMemoryBytesCalls)-1]
+}
+
+// GetCallCounts returns counts of various method calls
+func (t *TestStatReceiver) GetCallCounts() (recordsInMemory, recordsInMemoryBytes, checkpoint, eventToClient, eventsFromKinesis int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.recordsInMemoryCalls), len(t.recordsInMemoryBytesCalls), t.checkpointCalls, t.eventToClientCalls, len(t.eventsFromKinesisCalls)
+}
+
+// Reset clears all captured calls
+func (t *TestStatReceiver) Reset() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.recordsInMemoryCalls = nil
+	t.recordsInMemoryBytesCalls = nil
+	t.checkpointCalls = 0
+	t.eventToClientCalls = 0
+	t.eventsFromKinesisCalls = nil
+}
+
+// WaitForRecordsInMemoryCalls waits until at least expectedCalls RecordsInMemory calls are made
+// Returns true if the expected calls were made within the timeout
+func (t *TestStatReceiver) WaitForRecordsInMemoryCalls(expectedCalls int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if len(t.GetRecordsInMemoryCalls()) >= expectedCalls {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false
+}
+
+// WaitForRecordsInMemoryBytesCalls waits until at least expectedCalls RecordsInMemoryBytes calls are made
+// Returns true if the expected calls were made within the timeout
+func (t *TestStatReceiver) WaitForRecordsInMemoryBytesCalls(expectedCalls int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if len(t.GetRecordsInMemoryBytesCalls()) >= expectedCalls {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false
+}
+
+// TestMetricsBasic tests that the new metrics are reported to StatReceiver as expected
+func TestMetricsBasic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	streamName := "TestMetricsBasic_stream"
+	testStats := &TestStatReceiver{}
+
+	k, d := kinesisAndDynamoInstances(t)
+
+	defer func() {
+		err := cleanupTestEnvironment(t, k, d, streamName)
+		require.NoError(t, err, "Problems cleaning up the test environment")
+	}()
+
+	err := setupTestEnvironment(t, k, d, streamName, 1)
+	require.NoError(t, err, "Problems setting up the test environment")
+
+	// Configure with our test stat receiver
+	config := NewConfig().WithBufferSize(100).WithStats(testStats)
+	config = config.WithShardCheckFrequency(500 * time.Millisecond)
+	config = config.WithLeaderActionFrequency(500 * time.Millisecond)
+
+	kinsumer, err := NewWithInterfaces(k, d, streamName, *applicationName, "test_client", "", config)
+	require.NoError(t, err, "NewWithInterfaces() failed")
+
+	err = kinsumer.Run()
+	require.NoError(t, err, "kinsumer.Run() failed")
+	defer kinsumer.Stop()
+
+	// Send records through the system
+	recordCount := 200
+	err = spamStream(t, k, int64(recordCount), streamName)
+	require.NoError(t, err, "Problems sending test data")
+
+	// Wait for metrics to be reported (should happen every 1 second)
+	require.True(t, testStats.WaitForRecordsInMemoryCalls(2, 5*time.Second),
+		"Expected RecordsInMemory calls after sending records")
+	require.True(t, testStats.WaitForRecordsInMemoryBytesCalls(2, 5*time.Second),
+		"Expected RecordsInMemoryBytes calls after sending records")
+
+	// Verify metrics after sending records
+	recordsAfterSend := testStats.GetLastRecordsInMemory()
+	bytesAfterSend := testStats.GetLastRecordsInMemoryBytes()
+	assert.Equal(t, int64(200), recordsAfterSend, "Should have 200 records in memory after sending")
+	assert.Equal(t, int64(490), bytesAfterSend, "Should have 490 bytes in memory after sending") // 200 records * ~2.45 bytes avg
+
+	// Consume 100 records to trigger metric decreases (should cause 2 batches of 50 decrements)
+	var consumedCount int
+	timeout := time.After(15 * time.Second)
+	for consumedCount < 100 {
+		select {
+		case <-timeout:
+			t.Fatalf("Timeout consuming records, got %d", consumedCount)
+		default:
+			data, err := kinsumer.Next()
+			if err != nil {
+				t.Fatalf("Error from Next(): %v", err)
+			}
+			if data != nil {
+				consumedCount++
+			}
+		}
+	}
+
+	// Wait for additional metrics reporting after consumption
+	time.Sleep(2 * time.Second)
+
+	// Verify metrics after consuming records
+	recordsAfterConsume := testStats.GetLastRecordsInMemory()
+	bytesAfterConsume := testStats.GetLastRecordsInMemoryBytes()
+	assert.Equal(t, int64(100), recordsAfterConsume, "Should have 100 records in memory after consuming 100")
+	assert.Equal(t, int64(300), bytesAfterConsume, "Should have 300 bytes in memory after consuming 100")
+
+	// Verify the new metrics are working
+	recordCalls := testStats.GetRecordsInMemoryCalls()
+	byteCalls := testStats.GetRecordsInMemoryBytesCalls()
+
+	assert.True(t, len(recordCalls) > 0, "Should have RecordsInMemory calls")
+	assert.True(t, len(byteCalls) > 0, "Should have RecordsInMemoryBytes calls")
+	assert.Equal(t, len(recordCalls), len(byteCalls), "Record and byte calls should match")
+
+	// Verify at least one call showed non-zero values (records were in memory)
+	hasNonZeroRecords := false
+	hasNonZeroBytes := false
+	for _, count := range recordCalls {
+		if count > 0 {
+			hasNonZeroRecords = true
+			break
+		}
+	}
+	for _, bytes := range byteCalls {
+		if bytes > 0 {
+			hasNonZeroBytes = true
+			break
+		}
+	}
+
+	assert.True(t, hasNonZeroRecords, "Should have non-zero records in memory at some point")
+	assert.True(t, hasNonZeroBytes, "Should have non-zero bytes in memory at some point")
+
+	t.Logf("✓ Metrics test completed - RecordsInMemory calls: %v, RecordsInMemoryBytes calls: %v",
+		recordCalls, byteCalls)
+}
+
+// TestMetricsFiltering tests that metrics can be selectively enabled/disabled using the filteredStatReceiver
+func TestMetricsFiltering(t *testing.T) {
+	// Test that only RecordsInMemory metrics are captured when others are disabled
+	testStats := &TestStatReceiver{}
+
+	// Configure to only enable RecordsInMemory
+	metricsConfig := MetricsConfig{
+		EnableRecordsInMemory: true,
+		// All others default to false
+	}
+
+	// Create a filtered stat receiver using the new approach (simulating WithStats behavior)
+	filteredStats := newFilteredStatReceiver(testStats, metricsConfig)
+
+	// Call all methods on the filtered receiver
+	filteredStats.Checkpoint()
+	filteredStats.EventToClient(time.Now(), time.Now())
+	filteredStats.EventsFromKinesis(5, "shard-001", time.Second)
+	filteredStats.RecordsInMemory(100)
+	filteredStats.RecordsInMemoryBytes(500)
+
+	// Verify only RecordsInMemory was called on the underlying receiver
+	recordCount, byteCount, checkpointCount, eventToClientCount, eventsFromKinesisCount := testStats.GetCallCounts()
+
+	assert.Equal(t, 1, recordCount, "Should have 1 RecordsInMemory call")
+	assert.Equal(t, 0, byteCount, "Should have 0 RecordsInMemoryBytes calls (disabled)")
+	assert.Equal(t, 0, checkpointCount, "Should have 0 Checkpoint calls (disabled)")
+	assert.Equal(t, 0, eventToClientCount, "Should have 0 EventToClient calls (disabled)")
+	assert.Equal(t, 0, eventsFromKinesisCount, "Should have 0 EventsFromKinesis calls (disabled)")
+}
+
+// TestMetricsFilteringOrderIndependence tests that the order of WithStats() and WithMetricsConfig() doesn't matter
+func TestMetricsFilteringOrderIndependence(t *testing.T) {
+	testStats1 := &TestStatReceiver{}
+	testStats2 := &TestStatReceiver{}
+
+	metricsConfig := MetricsConfig{
+		EnableRecordsInMemory: true,
+		// All others default to false
+	}
+
+	// Test order 1: WithStats first, then WithMetricsConfig
+	config1 := NewConfig().
+		WithStats(testStats1).
+		WithMetricsConfig(metricsConfig)
+
+	// Test order 2: WithMetricsConfig first, then WithStats
+	config2 := NewConfig().
+		WithMetricsConfig(metricsConfig).
+		WithStats(testStats2)
+
+	// Simulate what happens in NewWithInterfaces - apply the filtering
+	filteredStats1 := newFilteredStatReceiver(config1.stats, config1.metricsConfig)
+	filteredStats2 := newFilteredStatReceiver(config2.stats, config2.metricsConfig)
+
+	// Call all methods on both filtered receivers
+	filteredStats1.Checkpoint()
+	filteredStats1.RecordsInMemory(100)
+	filteredStats1.RecordsInMemoryBytes(500)
+
+	filteredStats2.Checkpoint()
+	filteredStats2.RecordsInMemory(100)
+	filteredStats2.RecordsInMemoryBytes(500)
+
+	// Both should have identical behavior regardless of order
+	recordCount1, byteCount1, checkpointCount1, _, _ := testStats1.GetCallCounts()
+	recordCount2, byteCount2, checkpointCount2, _, _ := testStats2.GetCallCounts()
+
+	assert.Equal(t, recordCount1, recordCount2, "RecordsInMemory calls should be identical regardless of order")
+	assert.Equal(t, byteCount1, byteCount2, "RecordsInMemoryBytes calls should be identical regardless of order")
+	assert.Equal(t, checkpointCount1, checkpointCount2, "Checkpoint calls should be identical regardless of order")
+
+	// Verify the expected filtering (only RecordsInMemory should be called)
+	assert.Equal(t, 1, recordCount1, "Should have 1 RecordsInMemory call")
+	assert.Equal(t, 0, byteCount1, "Should have 0 RecordsInMemoryBytes calls (disabled)")
+	assert.Equal(t, 0, checkpointCount1, "Should have 0 Checkpoint calls (disabled)")
+}

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -14,11 +14,13 @@ type Statsd struct {
 	client statsd.StatSender
 }
 
-// New creates a new Statsd statreceiver with a new instance of a cactus statter
+// New creates a new Statsd statreceiver with buffering enabled by default
 func New(addr, prefix string) (*Statsd, error) {
 	sd, err := statsd.NewClientWithConfig(&statsd.ClientConfig{
-		Address: addr,
-		Prefix:  prefix,
+		Address:       addr,
+		Prefix:        prefix,
+		UseBuffered:   true,            // Enable buffering by default
+		FlushInterval: 1 * time.Second, // Sensible default flush interval
 	})
 
 	if err != nil {
@@ -57,4 +59,16 @@ func (s *Statsd) EventToClient(inserted, retrieved time.Time) {
 func (s *Statsd) EventsFromKinesis(num int, shardID string, lag time.Duration) {
 	_ = s.client.TimingDuration(fmt.Sprintf("kinsumer.%s.lag", shardID), lag, 1.0)
 	_ = s.client.Inc(fmt.Sprintf("kinsumer.%s.retrieved", shardID), int64(num), 1.0)
+}
+
+// RecordsInMemory implementation that writes to statsd a gauge metric about
+// the current number of records buffered in memory
+func (s *Statsd) RecordsInMemory(count int64) {
+	_ = s.client.Gauge("kinsumer.records_in_memory", count, 1.0)
+}
+
+// RecordsInMemoryBytes implementation that writes to statsd a gauge metric about
+// the current total payload bytes buffered in memory
+func (s *Statsd) RecordsInMemoryBytes(bytes int64) {
+	_ = s.client.Gauge("kinsumer.records_in_memory_bytes", bytes, 1.0)
 }


### PR DESCRIPTION
This PR introduces features related to management of the amount of data we pull into memory via kinsumer:

## Configurable limit on getRecords requests

Self explanatory

## maxConrrentShards setting

Uses a semaphore to limit the number of shards we pull data from at once. Previous to this, when there's a bottleneck on delivering data to the client, we would continue to pull data from the stream, which would cause excessive memory consumption. 

This feature allows us to limit the number of shards one pod pulls from - where there is no bottleneck we will cycle through shards continuously. When there is one, we will have a limit on the amount of shards we deal with, and therefore the memory we consume.

## Buffered data metric

Adds metrics recroding the number of records in memory after pulling from kinesis, and the approximate size in memory of those records.

Additionally, allows configuration of metrics in order to cost-control, since we don't necessarily need all the metrics that kinsumer outputs.


The other commits are just to factor things better and add tests - they're later in the chain to avoid the need for a rebase, since lots of this work was done concurrently.